### PR TITLE
Fix MongoDB connection error

### DIFF
--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -11,4 +11,4 @@ echo "Loading config fixtures"
 python manage.py loaddata fixtures/*.json
 
 echo "Running the server"
-python manage.py runserver 0.0.0.0:8000
+PYTHONUNBUFFERED=1 python manage.py runserver 0.0.0.0:8000

--- a/silo/__init__.py
+++ b/silo/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'silo.apps.SiloAppConfig'

--- a/silo/apps.py
+++ b/silo/apps.py
@@ -1,13 +1,16 @@
+import logging
+
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-
 from mongoengine import connection
 
+logger = logging.getLogger(__name__)
 
-class DjangoMongoEngineConfig(AppConfig):
-    name = 'django_mongoengine'
-    verbose_name = "Django-MongoEngine"
+
+class SiloAppConfig(AppConfig):
+    name = 'silo'
+    verbose_name = "Silo"
 
     def ready(self):
         if not hasattr(settings, 'MONGODB_DATABASES'):
@@ -15,4 +18,6 @@ class DjangoMongoEngineConfig(AppConfig):
                 "Missing `MONGODB_DATABASES` in settings.py")
 
         for alias, conn_settings in settings.MONGODB_DATABASES.items():
+            logger.info("Registering connection '%s' with args: %s",
+                        alias, conn_settings)
             connection.register_connection(alias, **conn_settings)

--- a/tola/settings/base.py
+++ b/tola/settings/base.py
@@ -324,9 +324,14 @@ LOGGING = {
             'level': 'INFO',
             'propagate': True,
         },
-        'silo.tests': {
+        'silo': {
             'handlers': ['file', 'console'],
-            'level': 'ERROR',
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'tola': {
+            'handlers': ['file', 'console'],
+            'level': 'INFO',
             'propagate': True,
         },
     },


### PR DESCRIPTION
Purpose
======

Fixes the exception that could not be found in tests:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/viewsets.py", line 86, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 489, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 449, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 486, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/mixins.py", line 48, in list
    return Response(serializer.data)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 739, in data
    ret = super(ListSerializer, self).data
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 263, in data
    self._data = self.to_representation(self.instance)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 657, in to_representation
    self.child.to_representation(item) for item in iterable
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 488, in to_representation
    attribute = field.get_attribute(instance)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/fields.py", line 445, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/fields.py", line 104, in get_attribute
    instance = getattr(instance, attr)
  File "/code/silo/models.py", line 363, in data_count
    return LabelValueStore.objects(silo_id=self.id).count()
  File "/usr/local/lib/python2.7/site-packages/mongoengine/queryset/manager.py", line 37, in __get__
    queryset = queryset_class(owner, owner._get_collection())
  File "/usr/local/lib/python2.7/site-packages/mongoengine/document.py", line 177, in _get_collection
    db = cls._get_db()
  File "/usr/local/lib/python2.7/site-packages/mongoengine/document.py", line 170, in _get_db
    return get_db(cls._meta.get("db_alias", DEFAULT_CONNECTION_NAME))
  File "/usr/local/lib/python2.7/site-packages/mongoengine/connection.py", line 166, in get_db
    conn = get_connection(alias)
  File "/usr/local/lib/python2.7/site-packages/mongoengine/connection.py", line 109, in get_connection
    raise ConnectionError(msg)
ConnectionError: You have not defined a default connection
```