### PR TITLE
Enable to import Google API settings from environment variables # 313

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -69,3 +69,5 @@ services:
       - TOLATABLES_MONGODB_PORT=27017
       - TOLA_ACTIVITY_API_URL=
       - TOLA_ACTIVITY_API_TOKEN=
+      - GOOGLE_API_CLIENT_ID=1090285679254-sle9dnkig5lv0gvnvgo5bd7js2i2u9cl.apps.googleusercontent.com
+      - GOOGLE_API_KEY=AIzaSyCnXYlzg5GBjOOk-_Mh8s36aF7OqIalyqE

--- a/templates2/base.html
+++ b/templates2/base.html
@@ -261,13 +261,21 @@
         <script>try{Typekit.load({ async: true });}catch(e){}</script>
 
         <script type="text/javascript">
-
-            // The Client ID obtained from the Google Developers Console.
+            {% if GOOGLE_API_CLIENT_ID %}
+            var clientId = "{{ GOOGLE_API_CLIENT_ID }}"
+            {% else %}
             var clientId = "445847194486-mah10ripofn1bl6q7pgi29ssvfhvq2uu.apps.googleusercontent.com"
-            // developerKey is the same as the Browser API key, at least, as of writing this code.
+            {% endif %}
+
+            {% if GOOGLE_API_KEY %}
+            var developerKey = '{{ GOOGLE_API_KEY }}';
+            {% else %}
             var developerKey = 'AIzaSyCwwfqoakFNLYHsWK1pMzVfYF9bhDTfOO0';
+            {% endif %}
+
             // The list of scopes to request access to is available at: https://developers.google.com/picker/docs/#otherviews
             var scope = ['https://www.googleapis.com/auth/drive.readonly'];
+
             var silo_id;
             var pickerApiLoaded = false;
             var oauthToken;

--- a/tola/context_processors.py
+++ b/tola/context_processors.py
@@ -2,6 +2,13 @@ from django.conf import settings
 from silo.models import Silo
 
 
+def google_oauth_settings(self):
+    return {
+        'GOOGLE_API_CLIENT_ID': settings.GOOGLE_API_CLIENT_ID,
+        'GOOGLE_API_KEY': settings.GOOGLE_API_KEY,
+    }
+
+
 def get_silos(self):
     if self.user.is_authenticated():
         all_my_silos = Silo.objects.filter(owner=self.user)

--- a/tola/context_processors.py
+++ b/tola/context_processors.py
@@ -1,6 +1,5 @@
-from silo.models import *
-from settings.local import ACTIVITY_URL
-from settings.local import TABLES_URL
+from django.conf import settings
+from silo.models import Silo
 
 
 def get_silos(self):
@@ -11,15 +10,8 @@ def get_silos(self):
     return {"all_my_silos": all_my_silos}
 
 
-# get the organization labels from the user for each level of workflow for display in templates
 def get_servers(request):
-
-    try:
-        activity_url = ACTIVITY_URL
-        tables_url = TABLES_URL
-    except Exception, e:
-        activity_url = "http://activity.toladata.io"
-        tables_url = "http://tables.toladata.io"
-
-
-    return {'ACTIVITY_URL': activity_url, 'TABLES_URL': tables_url}
+    return {
+        'ACTIVITY_URL': settings.ACTIVITY_URL,
+        'TABLES_URL': settings.TABLES_URL,
+    }

--- a/tola/settings/base.py
+++ b/tola/settings/base.py
@@ -133,31 +133,6 @@ FIXTURE_DIRS = (
 
 ########## TEMPLATE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#template-context-processors
-"""
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.tz',
-    'django.contrib.messages.context_processors.messages',
-    'django.core.context_processors.request',
-    'tola.context_processors.get_silos',
-    'tola.context_processors.get_servers',
-)
-
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#template-dirs
-TEMPLATE_DIRS = (
-    normpath(join(SITE_ROOT, 'templates')),
-)
-"""
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/tola/settings/local.py
+++ b/tola/settings/local.py
@@ -119,6 +119,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'tola.context_processors.get_silos',
                 'tola.context_processors.get_servers',
+                'tola.context_processors.google_oauth_settings',
             ],
             'builtins': [
                 'django.contrib.staticfiles.templatetags.staticfiles',
@@ -138,3 +139,6 @@ TABLES_URL = os.getenv('TABLES_URL')
 
 SOCIAL_AUTH_TOLA_KEY = os.getenv('SOCIAL_AUTH_TOLA_KEY')
 SOCIAL_AUTH_TOLA_SECRET = os.getenv('SOCIAL_AUTH_TOLA_SECRET')
+
+GOOGLE_API_CLIENT_ID = os.getenv('GOOGLE_API_CLIENT_ID')
+GOOGLE_API_KEY = os.getenv('GOOGLE_API_KEY')


### PR DESCRIPTION
Purpose
======

This is a first step to fix ticket:
https://github.com/toladata/TolaTables/issues/313

At the moment we have hardcoded variables in the templates, and we need new ones so we can configure them individually for each environment. For compatibility issues with Mercy Corps I can't delete the hardcoded ones.