### PR TITLE
Fix missing data in template

### DIFF
--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -34,10 +34,8 @@ class IndexViewTest(TestCase):
         self.assertEqual(context['silos_user'][2].name, 'priv_1')
         self.assertEqual(context['silos_user_public_total'], 2)
         self.assertEqual(context['silos_user_shared_total'], 1)
-        self.assertEqual(context['silos_public_total'][0].name, 'open')
-        self.assertEqual(context['silos_public_total'][1].name, 'pub_1')
-        self.assertEqual(context['silos_public_total'][2].name, 'pub_2')
-        self.assertEqual(len(context['silos_public_total']), 3)
+        self.assertEqual(context['silos_public'][0].name, 'open')
+        self.assertEqual(len(context['silos_public']), 1)
         self.assertEqual(len(context['readtypes']), 4)
         self.assertEqual(sorted(list(context['readtypes'])),
                          [u'CommCare', u'CustomForm', u'JSON', u'OneDrive'])
@@ -45,6 +43,43 @@ class IndexViewTest(TestCase):
                          [{'name': u'security', 'times_tagged': 4},
                           {'name': u'report', 'times_tagged': 4}]),
         self.assertEqual(context['site_name'], 'Track'),
+
+    def test_index_template_authenticated_user(self):
+        user_stranger = factories.User(username='stranger')
+        factories.Silo(owner=user_stranger, name='open', public=True)
+
+        user = factories.User()
+        silo_pub_1 = factories.Silo(owner=user, name='pub_1', public=True)
+        silo_pub_2 = factories.Silo(owner=user, name='pub_2', public=True)
+        silo_priv_1 = factories.Silo(owner=user, name='priv_1', public=False)
+        silo_shared_1 = factories.Silo(owner=user, name='shared_1', public=False,
+                       shared=[user_stranger])
+
+        request = self.factory.get('', follow=True)
+        request.user = user
+        view = views.IndexView.as_view()
+        response = view(request)
+        template_content = response.content
+
+        match = '<a href="{}">{}</a>'.format(
+            reverse('siloDetail', kwargs={'silo_id': silo_pub_1.pk}),
+            silo_pub_1.name)
+        self.assertEqual(template_content.count(match), 1)
+
+        match = '<a href="{}">{}</a>'.format(
+            reverse('siloDetail', kwargs={'silo_id': silo_pub_2.pk}),
+            silo_pub_2.name)
+        self.assertEqual(template_content.count(match), 1)
+
+        match = '<a href="{}">{}</a>'.format(
+            reverse('siloDetail', kwargs={'silo_id': silo_priv_1.pk}),
+            silo_priv_1.name)
+        self.assertEqual(template_content.count(match), 1)
+
+        match = '<a href="{}">{}</a>'.format(
+            reverse('siloDetail', kwargs={'silo_id': silo_shared_1.pk}),
+            silo_shared_1.name)
+        self.assertEqual(template_content.count(match), 1)
 
     def test_index_get_authenticated(self):
         silo = factories.Silo()

--- a/silo/views.py
+++ b/silo/views.py
@@ -62,6 +62,8 @@ class IndexView(View):
             filter(owner=request.user))
         silos_user_public_total = len([s for s in silos_user if s.public])
         silos_user_shared_total = len([s for s in silos_user if s.shared.all()])
+        silos_public = Silo.objects.prefetch_related('tags').filter(public=1).\
+            exclude(owner=request.user)
         readtypes = ReadType.objects.all().values_list('read_type', flat=True)
         tags = Tag.objects.filter(owner=request.user).\
                    annotate(times_tagged=Count('silos')).\
@@ -72,7 +74,7 @@ class IndexView(View):
             'silos_user': silos_user,
             'silos_user_public_total': silos_user_public_total,
             'silos_user_shared_total': silos_user_shared_total,
-            'silos_public_total': Silo.objects.filter(public=1),
+            'silos_public': silos_public,
             'readtypes': readtypes,
             'tags': tags,
             'site_name': site_name,

--- a/templates2/index.html
+++ b/templates2/index.html
@@ -73,19 +73,19 @@
                   {% for silo in silos_user %}
                   <tr>
                       <td>{{ silo.tag_list }}</td>
-                      <td><a href="/silo_detail/{{ silo.id }}/">{{ silo.name }}</a></td>
+                      <td><a href="{% url 'siloDetail' silo.id %}">{{ silo.name }}</a></td>
                       <td>{{ silo.description }}</td>
                       <td>{{ silo.public }}</td>
                       <td>{{ silo.created }}</td>
                   </tr>
                   {% endfor %}
-                  {% for item in get_public %}
+                  {% for silo in silos_public %}
                   <tr>
-                      <td>{{ item.tag_list }}</td>
-                      <td><a href="/silo_detail/{{ item.id }}/">{{ item.name }}</a></td>
-                      <td>{{ item.description }}</td>
-                      <td>{{ item.public }}</td>
-                      <td>{{ item.created }}</td>
+                      <td>{{ silo.tag_list }}</td>
+                      <td><a href="{% url 'siloDetail' silo.id %}">{{ silo.name }}</a></td>
+                      <td>{{ silo.description }}</td>
+                      <td>{{ silo.public }}</td>
+                      <td>{{ silo.created }}</td>
                   </tr>
                   {% endfor %}
               </table>

--- a/tola/settings/local.py
+++ b/tola/settings/local.py
@@ -70,7 +70,7 @@ GOOGLE_REDIRECT_URL = 'http://localhost:8000/oauth2callback/'
 
 
 ####### Tola Activity API #######
-TOLA_ACTIVITY_API_URL = os.getenv('TOLA_ACTIVITY_API_URL')
+TOLA_ACTIVITY_API_URL = os.getenv('TOLA_ACTIVITY_API_URL', '')
 TOLA_ACTIVITY_API_TOKEN = os.getenv('TOLA_ACTIVITY_API_TOKEN')
 
 ########## CACHE CONFIGURATION

--- a/tola/settings/test.py
+++ b/tola/settings/test.py
@@ -1,4 +1,4 @@
-from base import *
+from local import *
 
 
 ########## IN-MEMORY TEST DATABASE


### PR DESCRIPTION
Purpose
======

With the latest PR I skipped a couple of things which I fix in this one.

- Show public silos.
- Use reverse to get the URLs.
- Don't show repeated public silos which belong to the user.
- Changes test settings to use local, so we load the right templates.