### PR TITLE
Add endpoint persist data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ services:
   - mongodb
 script: python manage.py test
 before_install:
-  - openssl aes-256-cbc -d -a -in client_secrets.json.enc -out silo/client_secrets.json -k $SECRET_PASS
-  - sleep 15
+  # - openssl aes-256-cbc -d -a -in client_secrets.json.enc -out silo/client_secrets.json -k $SECRET_PASS
+  # - sleep 15
   - mongo test --eval 'db.createUser({user:"test", pwd:"test", roles:["readWrite"]});'

--- a/factories/silo_models.py
+++ b/factories/silo_models.py
@@ -1,10 +1,16 @@
 import random
 
+from django.utils import timezone
+
+from factory import DjangoModelFactory, LazyAttribute, SubFactory, \
+    post_generation
+
 from factory import (DjangoModelFactory, LazyAttribute, SubFactory,
                      post_generation, Iterator)
 
 from silo.models import (
     Country as CountryM,
+    LabelValueStore as LabelValueStoreM,
     Organization as OrganizationM,
     Read as ReadM,
     ReadType as ReadTypeM,
@@ -156,3 +162,10 @@ class Silo(DjangoModelFactory):
             # A list of formulacolumns were passed in, use them
             for formulacolumns in extracted:
                 self.formulacolumns.add(formulacolumns)
+
+
+class LabelValueStore(DjangoModelFactory):
+    class Meta:
+        model = LabelValueStoreM
+
+    create_date = timezone.now()

--- a/silo/tests/test_customformview.py
+++ b/silo/tests/test_customformview.py
@@ -1,14 +1,17 @@
 import json
+
 from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser
+
 from rest_framework.test import APIRequestFactory
 
 import factories
 from silo.tests import MongoTestCase
 from silo.api import CustomFormViewSet
-from silo.models import Silo
+from silo.models import Silo, LabelValueStore
 
 
-class CustomFormViewsTest(TestCase, MongoTestCase):
+class CustomFormHasDataTest(TestCase, MongoTestCase):
     def setUp(self):
         factories.ReadType(read_type='CustomForm')
         self.tola_user = factories.TolaUser()
@@ -49,11 +52,19 @@ class CustomFormViewsTest(TestCase, MongoTestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class CustomFormCreateViewsTest(TestCase, MongoTestCase):
+class CustomFormCreateViewTest(TestCase, MongoTestCase):
     def setUp(self):
         factories.ReadType(read_type='CustomForm')
         self.tola_user = factories.TolaUser()
         self.factory = APIRequestFactory()
+        self.silo_id = None
+
+    def tearDown(self):
+        if self.silo_id:
+            # Have to remove the created lvs
+            lvss = LabelValueStore.objects.filter(silo_id=self.silo_id)
+            for lvs in lvss:
+                lvs.delete()
 
     def test_create_customform_superuser(self):
         self.tola_user.user.is_staff = True
@@ -91,6 +102,9 @@ class CustomFormCreateViewsTest(TestCase, MongoTestCase):
 
         self.assertEqual(response.status_code, 201)
 
+        # For the tearDown
+        self.silo_id = response.data['id']
+
     def test_create_customform_missing_data_superuser(self):
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
@@ -126,7 +140,7 @@ class CustomFormCreateViewsTest(TestCase, MongoTestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class CustomFormUpdateViewsTest(TestCase):
+class CustomFormUpdateViewTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
@@ -216,3 +230,142 @@ class CustomFormUpdateViewsTest(TestCase):
         response = view(request, pk=silo.pk)
 
         self.assertEqual(response.status_code, 403)
+
+
+class CustomFormSaveDataViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+
+        self.read = factories.Read(
+            owner=self.tola_user.user,
+            type=factories.ReadType(read_type='CustomForm'),
+            read_name='Lennon Survey',
+        )
+        wflvl1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        self.silo = factories.Silo(
+            name='Lennon Survey',
+            workflowlevel1=[wflvl1],
+            owner=self.tola_user.user,
+            columns='[{"name": "name", "type": "text"},'
+                    '{"name": "age", "type": "number"},'
+                    '{"name": "city", "type": "text"}]',
+            reads=[self.read],
+            public=False
+        )
+
+    def tearDown(self):
+        # Have to remove the created lvs
+        lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
+        for lvs in lvss:
+            lvs.delete()
+
+    def test_save_data_customform_no_lvs_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        data = {
+            'silo_id': self.silo.id,
+            'data': {
+                'name': 'John Lennon',
+                'age': 40,
+                'city': 'Liverpool'
+            }
+        }
+
+        request = self.factory.post('api/customform/%s/save_data' %
+                                    self.silo.id, data=json.dumps(data),
+                                    content_type='application/json')
+        request.user = self.tola_user.user
+        view = CustomFormViewSet.as_view({'post': 'save_data'})
+        response = view(request)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data['detail'], 'Not found.')
+
+    def test_save_data_customform_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        factories.LabelValueStore(silo_id=self.silo.id, read_id=self.read.id)
+
+        data = {
+            'silo_id': self.silo.id,
+            'data': {
+                'name': 'John Lennon',
+                'age': 40,
+                'city': 'Liverpool'
+            }
+        }
+
+        request = self.factory.post('api/customform/%s/save_data' %
+                                    self.silo.id, data=json.dumps(data),
+                                    content_type='application/json')
+        request.user = self.tola_user.user
+        view = CustomFormViewSet.as_view({'post': 'save_data'})
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_save_data_customform_missing_data_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        factories.LabelValueStore(silo_id=self.silo.id, read_id=self.read.id)
+
+        data = {
+            'data': {
+                'name': 'John Lennon',
+                'age': 40,
+                'city': 'Liverpool'
+            }
+        }
+
+        request = self.factory.post('api/customform/%s/save_data' %
+                                    self.silo.id, data=json.dumps(data),
+                                    content_type='application/json')
+        request.user = self.tola_user.user
+        view = CustomFormViewSet.as_view({'post': 'save_data'})
+        response = view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['detail'], 'Missing data.')
+
+    def test_save_data_customform_normaluser(self):
+        factories.LabelValueStore(silo_id=self.silo.id, read_id=self.read.id)
+
+        data = {
+            'silo_id': self.silo.id,
+            'data': {
+                'name': 'John Lennon',
+                'age': 40,
+                'city': 'Liverpool'
+            }
+        }
+
+        request = self.factory.post('api/customform/%s/save_data' %
+                                    self.silo.id, data=json.dumps(data),
+                                    content_type='application/json')
+        request.user = self.tola_user.user
+        view = CustomFormViewSet.as_view({'post': 'save_data'})
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_save_data_customform_no_data_normaluser(self):
+        factories.LabelValueStore(silo_id=self.silo.id, read_id=self.read.id)
+
+        data = {}
+
+        request = self.factory.post('api/customform/%s/save_data' %
+                                    self.silo.id, data=data)
+        request.user = self.tola_user.user
+        view = CustomFormViewSet.as_view({'post': 'save_data'})
+        response = view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['detail'], 'No data sent.')

--- a/tola/util.py
+++ b/tola/util.py
@@ -1,29 +1,28 @@
-import unicodedata
 import datetime
 import urllib2
 import json
 import base64
 import requests
+import logging
 
-from django.utils.encoding import smart_text
 from django.utils import timezone
-from django.utils.encoding import smart_str, smart_unicode
+from django.utils.encoding import smart_str
 from django.conf import settings
-from django.contrib.auth.models import User
 
-from silo.models import Read, Silo, LabelValueStore, TolaUser, Country, ThirdPartyTokens, Organization
+from silo.models import (Read, Silo, LabelValueStore, TolaUser, Country,
+                         ThirdPartyTokens, Organization)
 from django.contrib import messages
-import pymongo
-from bson.objectid import ObjectId
 from pymongo import MongoClient
 
-from os import walk, listdir
-from django.apps import apps
+from collections import deque
 
-from collections import Counter, deque
+
+logger = logging.getLogger("tola")
+
 
 def mean(lst):
     return float(sum(lst))/len(lst)
+
 
 def median(lst):
     lst = sorted(lst)
@@ -35,8 +34,10 @@ def median(lst):
     else:
             return sum(lst[n//2-1:n//2+1])/2.0
 
+
 def mode(lst):
     return max(set(lst), key=lst.count)
+
 
 def parseMathInstruction(operation):
     if operation == "sum":
@@ -44,48 +45,15 @@ def parseMathInstruction(operation):
     elif operation == "mean":
         return mean
     elif operation == "median":
-       return median
+        return median
     elif operation == "mode":
-       return mode
+        return mode
     elif operation == "max":
-       return max
+        return max
     elif operation == "min":
-       return min
+        return min
     else:
         raise TypeError(operation)
-
-# Obsolete used for making sure every row in mongodb has the same columns
-# def combineColumns(silo_id):
-#     client = MongoClient(settings.MONGODB_HOST)
-#     db = client.tola
-#     lvs = json.loads(LabelValueStore.objects(silo_id = silo_id).to_json())
-#     cols = []
-#     for l in lvs:
-#         cols.extend([k for k in l.keys() if k not in cols])
-#
-#     for l in lvs:
-#         for c in cols:
-#             if c not in l.keys():
-#                 db.label_value_store.update_one(
-#                     {"_id": ObjectId(l['_id']['$oid'])},
-#                     {"$set": {c: ''}},
-#                     False
-#                 )
-#     return True
-
-#obslolete and not used anywhere
-# def siloToDict(silo):
-#     parsed_data = {}
-#     key_value = 1
-#     for d in silo:
-#         label = unicodedata.normalize('NFKD', d.field.name).encode('ascii','ignore')
-#         value = unicodedata.normalize('NFKD', d.char_store).encode('ascii','ignore')
-#         row = unicodedata.normalize('NFKD', d.row_number).encode('ascii','ignore')
-#         parsed_data[key_value] = {label : value}
-#
-#         key_value += 1
-#
-#     return parsed_data
 
 
 def saveDataToSilo(silo, data, read=-1, user=None):
@@ -98,19 +66,15 @@ def saveDataToSilo(silo, data, read=-1, user=None):
     read -- the read object, optional only for backwards compatability
     user -- an optional parameter to use if its necessary to retrieve from ThirdPartyTokens
     """
-    print read
-    print read.type.read_type
-    print read.id
     try:
         if read.type.read_type == "ONA" and user:
-            saveOnaDataToSilo(silo,data,read,user)
+            saveOnaDataToSilo(silo, data, read, user)
         read_source_id = read.id
     except AttributeError as e:
         read_source_id = read.id
 
     unique_fields = silo.unique_fields.all()
     skipped_rows = set()
-    enc = "latin-1"
     keys = []
     fieldToType = getColToTypeDict(silo)
     for counter, row in enumerate(data):
@@ -119,10 +83,10 @@ def saveDataToSilo(silo, data, read=-1, user=None):
         for uf in unique_fields:
             try:
                 filter_criteria.update({str(uf.name): str(row[uf.name])})
-            except KeyError:
+            except KeyError as e:
                 # when this excpetion occurs, it means that the col identified
                 # as the unique_col is not present in the fetched dataset
-                pass
+                logger.info(e)
 
         # if filter_criteria is set, then update it with current silo_id
         # else set filter_criteria to some non-existent key and value so
@@ -131,26 +95,26 @@ def saveDataToSilo(silo, data, read=-1, user=None):
         if filter_criteria:
             filter_criteria.update({'silo_id': silo.id})
         else:
-            filter_criteria.update({"nonexistentkey":"NEVER0101010101010NEVER"})
+            filter_criteria.update({"nonexistentkey": "NEVER0101010101010NEVER"})
 
         try:
             lvs = LabelValueStore.objects.get(**filter_criteria)
-            #print("updating")
             setattr(lvs, "edit_date", timezone.now())
             lvs.read_id = read_source_id
         except LabelValueStore.DoesNotExist as e:
+            logger.info(e)
             lvs = LabelValueStore()
             lvs.silo_id = silo.pk
             lvs.create_date = timezone.now()
             lvs.read_id = read_source_id
         except LabelValueStore.MultipleObjectsReturned as e:
-            for k,v in filter_criteria.iteritems():
-                skipped_rows.add("%s=%s" % (str(k),str(v)))
-            #print("skipping")
+            logger.info(e)
+            for k, v in filter_criteria.iteritems():
+                skipped_rows.add("%s=%s" % (str(k), str(v)))
             continue
 
         counter = 0
-        # set the fields in the curernt document and save it
+        # set the fields in the current document and save it
         for key, val in row.iteritems():
             if key == "" or key is None or key == "silo_id": continue
             elif key == "id" or key == "_id": key = "user_assigned_id"
@@ -162,6 +126,7 @@ def saveDataToSilo(silo, data, read=-1, user=None):
                 try:
                     val = int(val)
                 except ValueError as e:
+                    logger.warning(e)
                     # skip this one
                     # add message that this is skipped
                     continue
@@ -169,6 +134,7 @@ def saveDataToSilo(silo, data, read=-1, user=None):
                 try:
                     val = float(val)
                 except ValueError as e:
+                    logger.warning(e)
                     # skip this one
                     # add message that this is skipped
                     continue
@@ -189,15 +155,15 @@ def saveDataToSilo(silo, data, read=-1, user=None):
     return res
 
 
-#IMPORT JSON DATA
-def importJSON(read_obj, user, remote_user = None, password = None, silo_id = None, silo_name = None, return_data = False):
+# IMPORT JSON DATA
+def importJSON(read_obj, user, remote_user=None, password=None, silo_id=None, silo_name=None, return_data=False):
     # set date time stamp
     today = datetime.date.today()
     today.strftime('%Y-%m-%d')
     today = str(today)
     try:
         request2 = urllib2.Request(read_obj.read_url)
-        # If the read_obj has token then use it; otherwise, check for login info.
+        # If the read_obj has token then use it; otherwise, check for login info
         if read_obj.token:
             request2.add_header("Authorization", "Basic %s" % read_obj.token)
         elif remote_user and password:
@@ -205,41 +171,40 @@ def importJSON(read_obj, user, remote_user = None, password = None, silo_id = No
             request2.add_header("Authorization", "Basic %s" % base64string)
         else:
             pass
-        #retrieve JSON data from formhub via auth info
+        # retrieve JSON data from formhub via auth info
         json_file = urllib2.urlopen(request2)
-        silo = None
 
         if silo_name:
             silo = Silo(name=silo_name, owner=user, public=False, create_date=today)
             silo.save()
         else:
-            silo = Silo.objects.get(id = silo_id)
+            silo = Silo.objects.get(id=silo_id)
 
         silo.reads.add(read_obj)
         silo_id = silo.id
 
-        #create object from JSON String
+        # create object from JSON String
         data = json.load(json_file)
         json_file.close()
 
-        #if the caller of this function does not want to the data to go into the silo yet
+        # if the caller of this function does not want to the data to go into
+        #  the silo yet
         if return_data:
             return data
 
-
-        skipped_rows = saveDataToSilo(silo, data, read_obj)
-        return (messages.SUCCESS, "Data imported successfully.", str(silo_id))
+        saveDataToSilo(silo, data, read_obj)
+        return messages.SUCCESS, "Data imported successfully.", str(silo_id)
     except Exception as e:
         if return_data:
             return None
-        return (messages.ERROR, "An error has occured: %s" % e, str(silo_id))
+        return messages.ERROR, "An error has occured: %s" % e, str(silo_id)
+
 
 def getSiloColumnNames(id):
     """
     takes silo_id and returns the shown columns in order in O(n)
     """
     silo = Silo.objects.get(pk=id)
-    #cols_raw = [x.get('name') for x in json.loads(silo.columns)]
     cols_raw = json.loads(silo.columns)
     hidden_cols = set(json.loads(silo.hidden_columns))
     hidden_cols = hidden_cols.union(['id', 'silo_id', 'read_id', 'create_date', 'edit_date', 'editted_date'])
@@ -253,6 +218,7 @@ def getSiloColumnNames(id):
 
     return list(cols_final)
 
+
 def getCompleteSiloColumnNames(id):
     """
     This gets all the column names including the hidden ones in order
@@ -262,6 +228,7 @@ def getCompleteSiloColumnNames(id):
     silo = Silo.objects.get(pk=id)
     return [x if isinstance(x, basestring) else x.get('name') for x in json.loads(silo.columns)]
 
+
 def addColsToSilo(silo, columns, col_types = {}):
     """
     This adds columns to a silo object while preserving order in O(n)
@@ -269,16 +236,16 @@ def addColsToSilo(silo, columns, col_types = {}):
     silo -- a silo object
     columns -- an iterable containing columns to add
     """
-    #make sure there are no duplicate columns
+    # make sure there are no duplicate columns
     columns_set = set(columns)
-    print columns
     if len(columns_set) != len(columns):
         raise ValueError('Duplicate columns are not allowed')
     silo_cols = json.loads(silo.columns)
-    silo_cols_set = set([x['name'] for x in silo_cols]) #this is done to decrease lookup time from n to 1
+    silo_cols_set = set([x['name'] for x in silo_cols])  # this is done to decrease lookup time from n to 1
     silo_cols.extend([{'name' : x, 'type' : col_types.get(x, 'string')} for x in columns if x not in silo_cols_set])
     silo.columns = json.dumps(silo_cols)
     silo.save()
+
 
 def deleteSiloColumns(silo, columns):
     """
@@ -306,6 +273,7 @@ def hideSiloColumns(silo, cols):
     silo.hidden_columns = json.dumps(list(hidden_cols))
     silo.save()
 
+
 def unhideSiloColumns(silo, cols):
     """
     take a list of columns and unhides it
@@ -314,6 +282,7 @@ def unhideSiloColumns(silo, cols):
     hidden_cols = hidden_cols.difference(cols)
     silo.hidden_columns = json.dumps(list(hidden_cols))
     silo.save()
+
 
 def getColToTypeDict(silo):
     """
@@ -328,10 +297,8 @@ def getColToTypeDict(silo):
 
 
 def user_to_tola(backend, user, response, *args, **kwargs):
-    print(user, response, args, kwargs)
 
     # Add a google auth user to the tola profile
-    default_country = Country.objects.first()
     remote_user = response.get('tola_user')
 
     # Only import fields to Tables that are required
@@ -346,21 +313,20 @@ def user_to_tola(backend, user, response, *args, **kwargs):
     del remote_org['url']
     del remote_org['industry']  # ignore for now
     del remote_org['sector']  # ignore for now
-    organization, org_created = Organization.objects.update_or_create(remote_org,
-                                                                      organization_uuid=remote_org['organization_uuid'])
-
+    organization, org_created = Organization.objects.update_or_create(
+        remote_org, organization_uuid=remote_org['organization_uuid'])
 
     tola_user_defaults['organization'] = organization
 
-    userprofile, tolauser_created = TolaUser.objects.update_or_create(tola_user_defaults,
-        user=user)
+    TolaUser.objects.update_or_create(tola_user_defaults, user=user)
 
 
-#gets the list of apps to import data
+# gets the list of apps to import data
 def getImportApps():
     return settings.DATASOURCE_APPS
 
-#gets the list of apps to import data by their verbose name
+
+# gets the list of apps to import data by their verbose name
 def getImportAppsVerbose():
     folders = getImportApps()
     apps = [[folder,folder] for folder in folders]
@@ -376,6 +342,7 @@ def getImportAppsVerbose():
                 break
     return apps
 
+
 def ona_parse_type_group(data, form_data, parent_name, silo, read):
     """
     if data is a type group this replaces the compound key names with their labels
@@ -387,29 +354,28 @@ def ona_parse_type_group(data, form_data, parent_name, silo, read):
     """
     for field in form_data:
 
-
         if field["type"] == "group":
-            ona_parse_type_group(data,field['children'],parent_name + field['name']+"/",silo,read)
+            ona_parse_type_group(data, field['children'], parent_name + field['name']+"/", silo, read)
         else:
             for entry in data:
                 if field['type'] == "repeat":
-                    ona_parse_type_repeat(entry.get(parent_name + field['name'], []),\
-                                        field['children'],\
-                                        parent_name + field['name']+"/",silo,read)
+                    ona_parse_type_repeat(entry.get(parent_name + field['name'], []), field['children'], parent_name + field['name']+"/", silo, read)
                 if 'label' in field:
                     try:
                         key = frozenset(field['label'].items())
                         for x in key:
                             entry[x] = entry.pop(parent_name + field['name'])
                     except KeyError as e:
-                        pass
+                        logger.warning(e)
 
-        #add an asociation between a column, label and its type to the columnType database
+        # add an association between a column, label and its type to the
+        # columnType database
         name = ""
         if 'label' in field:
             name = field['label']
         else:
             name = field['name']
+
 
 def ona_parse_type_repeat(data, form_data, parent_name, silo, read):
     """
@@ -423,18 +389,17 @@ def ona_parse_type_repeat(data, form_data, parent_name, silo, read):
     """
     for field in form_data:
         if field["type"] == "group":
-            ona_parse_type_group(data,field['children'],parent_name + field['name']+"/",silo,read)
+            ona_parse_type_group(data, field['children'], parent_name + field['name']+"/", silo, read)
         else:
             for entry in data:
                 if field['type'] == "repeat":
-                    ona_parse_type_repeat(entry.get(parent_name + field['name'],[]),\
-                                        field['children'],\
-                                        parent_name + field['name']+"/",silo,read)
+                    ona_parse_type_repeat(entry.get(parent_name + field['name'], []), field['children'], parent_name + field['name'] + "/", silo, read)
                 if 'label' in field:
                     try:
                         entry[field['label']] = entry.pop(parent_name + field['name'])
                     except KeyError as e:
-                        pass
+                        logger.warning(e)
+
 
 def saveOnaDataToSilo(silo, data, read, user):
     """
@@ -448,21 +413,23 @@ def saveOnaDataToSilo(silo, data, read, user):
     form_metadata -- a python dictionary from ONA storing column names labels and types
     read -- a read object
     """
-    #If in the future the ONA data needs to be adjusted to remove undesirable fields it can be done here
+    # If in the future the ONA data needs to be adjusted to remove
+    # undesirable fields it can be done here
     ona_token = ThirdPartyTokens.objects.get(user=user, name="ONA")
-    url = "https://api.ona.io/api/v1/forms/"+ read.read_url.split('/')[6] +"/form.json"
+    url = "https://api.ona.io/api/v1/forms/" + read.read_url.split('/')[6] + "/form.json"
     response = requests.get(url, headers={'Authorization': 'Token %s' % ona_token.token})
     form_metadata = json.loads(response.content)
 
-
-    #if this is true than the data isn't a form so proceed to saveDataToSilo normally
+    # if this is true than the data isn't a form so proceed to
+    # saveDataToSilo normally
     if "detail" in form_metadata:
         return
     else:
         ona_parse_type_group(data,form_metadata['children'],"",silo,read)
         return
 
-def calculateFormulaColumn(lvs,operation,columns,formula_column_name):
+
+def calculateFormulaColumn(lvs, operation, columns, formula_column_name):
     """
     This function calculates the math operation for a queryset of label_value_store using defined
     columns
@@ -475,7 +442,7 @@ def calculateFormulaColumn(lvs,operation,columns,formula_column_name):
     """
 
     if not columns or len(columns) == 0:
-        return (messages.ERROR, "No columns were selected for operation")
+        return messages.ERROR, "No columns were selected for operation"
 
     calc = parseMathInstruction(operation)
     if type(calc) == tuple:
@@ -484,14 +451,15 @@ def calculateFormulaColumn(lvs,operation,columns,formula_column_name):
     calc_fails = []
     for i, entry in enumerate(lvs):
         entry = calculateFormula(entry, calc, columns, formula_column_name)
-        if(entry[1]):
+        if entry[1]:
             entry[0].save()
         else:
             entry[0].save()
             calc_fails.append(i)
     if len(calc_fails) == 0:
-        return (messages.SUCCESS, "Successfully performed operations")
-    return (messages.WARNING, "Non-numeric data detected in rows %s" % str(calc_fails))
+        return messages.SUCCESS, "Successfully performed operations"
+    return messages.WARNING, "Non-numeric data detected in rows %s" % str(calc_fails)
+
 
 def calculateFormula(entry, calc, columns, formula_column_name):
     """
@@ -511,10 +479,12 @@ def calculateFormula(entry, calc, columns, formula_column_name):
         entry.edit_date = timezone.now()
         success = True
     except (ValueError, KeyError) as operation:
-        setattr(entry,formula_column_name,"Error")
+        logger.warning(operation)
+        setattr(entry,formula_column_name, "Error")
         entry.edit_date = timezone.now()
         success = False
-    return (entry, success)
+    return entry, success
+
 
 def calculateFormulaCell(entry, silo):
     """
@@ -526,12 +496,12 @@ def calculateFormulaCell(entry, silo):
     returns entry
     """
     formula_columns = silo.formulacolumns.all()
-    calc_fail = []
     for column in formula_columns:
         calculation_to_do = parseMathInstruction(column.operation)
-        entry = calculateFormula(entry,calculation_to_do,json.loads(column.mapping),column.column_name)
+        entry = calculateFormula(entry, calculation_to_do, json.loads(column.mapping), column.column_name)
         entry = entry[0]
     return entry
+
 
 def makeQueryForHiddenRow(row_filter):
     """
@@ -541,20 +511,20 @@ def makeQueryForHiddenRow(row_filter):
     """
     query = {}
     empty = [""]
-    #find and add any extra empty characters
+    # find and add any extra empty characters
     for condition in row_filter:
         if condition.get("logic","") == "BLANKCHAR":
             empty.append(condition.get("conditional", ""))
-    #now add to the query
+    # now add to the query
     for condition in row_filter:
-        #this does string comparisons
+        # this does string comparisons
         num_to_compare = [condition.get("number","")]
         try:
-            num_to_compare.append(float(condition.get("number","")))
-            num_to_compare.append(int(condition.get("number","")))
+            num_to_compare.append(float(condition.get("number", "")))
+            num_to_compare.append(int(condition.get("number", "")))
         except Exception as e:
-            pass
-        #specify the part of the dictionary to add to
+            logger.warning(e)
+        # specify the part of the dictionary to add to
         if condition.get("logic","") == "AND":
             to_add = query
         elif condition.get("logic","") == "OR":
@@ -608,9 +578,8 @@ def makeQueryForHiddenRow(row_filter):
                         to_add[column]['$nin'].extend(num_to_compare)
                     except KeyError as e:
                         to_add[column]['$nin'] = num_to_compare
-            #for lt, gt, lte, gte need to take the most exclusive condition
 
-    #conver the $or area to be properly formatted for a query
+    # convert the $or area to be properly formatted for a query
     or_items = query.get("$or", {})
     if len(or_items) > 0:
         query["$or"] = []
@@ -619,6 +588,7 @@ def makeQueryForHiddenRow(row_filter):
 
     query = json.dumps(query)
     return query
+
 
 def getNewestDataDate(silo_id):
     """
@@ -629,9 +599,11 @@ def getNewestDataDate(silo_id):
 
     return newest_record[0]['create_date']
 
+
 # to convert floating point strings to integers
 def strToInt(string):
     return int(float(string))
+
 
 def setSiloColumnType(silo_pk, column, column_type):
     # TO DO: check for acceptable column type
@@ -651,8 +623,8 @@ def setSiloColumnType(silo_pk, column, column_type):
     db = MongoClient(settings.MONGO_URI).tola
     bulk = db.label_value_store.initialize_ordered_bulk_op()
 
-    if (db.label_value_store.find({'silo_id' : silo_pk, column : {'$not' : {'$exists' : True}}}).count() > 0):
-        return (messages.ERROR, 'Faluire to set column type due to not all rows having designated column')
+    if db.label_value_store.find({'silo_id' : silo_pk, column : {'$not' : {'$exists' : True}}}).count() > 0:
+        return messages.ERROR, 'Faluire to set column type due to not all rows having designated column'
 
     # find a non castable row for int/float
     if column_type in ('int', 'float'):
@@ -664,43 +636,19 @@ def setSiloColumnType(silo_pk, column, column_type):
         )
         if len(res['results']) > 1:
             unparsed_rows = [x for x in res['results'] if x['_id']]
-            return (messages.ERROR, '%s is/are not parsable to %s' % (unparsed_rows[0]['value'], column_type))
+            return messages.ERROR, '%s is/are not parsable to %s' % (unparsed_rows[0]['value'], column_type)
 
-
-    #change type in mysql database
+    # change type in mysql database
     silo = Silo.objects.get(pk=silo_pk)
     silo_cols = json.loads(silo.columns)
     for col in silo_cols:
-        if(col['name'] == column):
+        if col['name'] == column:
             col['type'] = column_type
             break
     silo.columns = json.dumps(silo_cols)
     silo.save()
 
-    # now redo validation for every silo
-
-    # this replaces validation not adds to it
-    # res = db.command(
-    #     'collMod',
-    #     'label_value_store',
-    #     validator = { '$or': [
-    #         {'$and' : [
-    #             {'silo_id' : silo_pk},
-    #             {column : {'$type' : column_type}},
-    #             {column : {'$exists' : True}}
-    #         ]},
-    #         {'$and' : [
-    #             {'silo_id' : silo_pk2},
-    #             {column : {'$type' : column_type}},
-    #             {column : {'$exists' : True}}
-    #         ]},
-    #         {'silo_id' : {'$nin' : [silo_pk, silo_pk2]}},
-    #     ]},
-    #     validationLevel = "moderate",
-    #     validationAction = "error"
-    # )
-
-    counter = 0;
+    counter = 0
     for data in db.label_value_store.find({'silo_id' : silo_pk}):
         updoc = {
             "$set": {}
@@ -708,18 +656,14 @@ def setSiloColumnType(silo_pk, column, column_type):
         updoc["$set"][column] = cast_fnct(data[column])
         # queue the update
         bulk.find({'_id': data['_id']}).update(updoc)
-        counter+=1
+        counter += 1
         # Drain and re-initialize every 1000 update statements
-        if (counter % 1000 == 0):
+        if counter % 1000 == 0:
             bulk.execute()
             bulk = db.label_value_store.initialize_ordered_bulk_op();
 
-
     # Add the rest in the queue
-    if (counter % 1000 != 0):
+    if counter % 1000 != 0:
         bulk.execute()
 
-
-
-
-    return (messages.SUCCESS, 'All success columns parsed succesfully')
+    return messages.SUCCESS, 'All success columns parsed succesfully'


### PR DESCRIPTION
## Purpose
When a custom form is published, we should be able to collect data with it, in other words, the input data has to be persisted

#### Further Info:
Related ticket: TolaDataV2/[#611](https://github.com/toladata/TolaDataV2/issues/611)