### PR TITLE
Fix oauth pipeline

### DIFF
--- a/tola/auth_pipeline.py
+++ b/tola/auth_pipeline.py
@@ -82,13 +82,20 @@ def user_to_tola(backend, user, response, *args, **kwargs):
             'privacy_disclaimer_accepted':
                 remote_user['privacy_disclaimer_accepted']
         }
-        del remote_org['url']
-        del remote_org['industry']  # ignore for now
-        del remote_org['sector']  # ignore for now
-        del remote_org['chargebee_subscription_id']  # ignore for now
-        del remote_org['chargebee_used_seats']  # ignore for now
+
+        data_org = {
+            'organization_uuid': remote_org['organization_uuid'],
+            'name': remote_org['name'],
+            'description': remote_org.get('description'),
+            'organization_url': remote_org.get('organization_url'),
+            'level_1_label': remote_org.get('level_1_label', ''),
+            'level_2_label': remote_org.get('level_2_label', ''),
+            'level_3_label': remote_org.get('level_3_label', ''),
+            'level_4_label': remote_org.get('level_4_label', '')
+        }
+
         organization, org_created = Organization.objects.update_or_create(
-                remote_org, organization_uuid=remote_org['organization_uuid'])
+            data_org, organization_uuid=data_org['organization_uuid'])
 
         tola_user_fields['organization'] = organization
 

--- a/tola/tests/test_oauth.py
+++ b/tola/tests/test_oauth.py
@@ -56,12 +56,7 @@ class OAuthTest(TestCase):
             },
             'organization': {
                 'name': self.org.name,
-                'url': '',
-                'industry': '',
-                'sector': '',
                 'organization_uuid': self.org.organization_uuid,
-                'chargebee_subscription_id': '',
-                'chargebee_used_seats': ''
             }
         }
 
@@ -98,6 +93,33 @@ class OAuthTest(TestCase):
         tola_user = TolaUser.objects.get(user=user)
 
         self.assertEqual(tola_user.organization.name, new_org.name)
+
+    def test_user_to_tola_org_extra_fields(self):
+        response = {
+            'tola_user': {
+                'tola_user_uuid': '13dac835-3860-4d9d-807e-d36a3c106057',
+                'name': 'John Lennon',
+                'employee_number': None,
+                'title': 'mr',
+                'privacy_disclaimer_accepted': True,
+            },
+            'organization': {
+                'name': self.org.name,
+                'url': '',
+                'industry': '',
+                'sector': '',
+                'organization_uuid': self.org.organization_uuid,
+                'chargebee_subscription_id': '',
+                'chargebee_used_seats': ''
+            }
+        }
+
+        user = factories.User(first_name='John', last_name='Lennon')
+        auth_pipeline.user_to_tola(None, user, response)
+        tola_user = TolaUser.objects.get(name='John Lennon')
+
+        self.assertEqual(tola_user.name, response['tola_user']['name'])
+        self.assertEqual(tola_user.organization.name, self.org.name)
 
     def test_get_or_create_user_without_user(self):
         """


### PR DESCRIPTION
## Purpose
When a user uses the social OAuth, the system tries to update or create an organization based on the org from Activity but it fails because it doesn't have the field `oauth_domains`.

## Approach
I'm creating org data with the used fields instead of using the data from the response and removing the unused fields.

### Furter Info
Related ticket: #418 
