### PR TITLE
Update the do_merge view to redirect the user to silo detail page

### DIFF
--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -597,18 +597,16 @@ class DoMergeViewTest(TestCase):
         request = self.factory.post('', data=data)
         request.user = self.tola_user.user
         response = views.do_merge(request)
-        content = json.loads(response.content)
 
         silo = Silo.objects.get(name=merged_silo_name)
-        self.assertEqual(content['status'], 'success')
-        self.assertIn('The merged table is accessible at', content['message'])
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/silo_detail/{}/'.format(silo.id))
         self.assertIn(left_read, silo.reads.all())
         self.assertIn(right_read, silo.reads.all())
 
     @patch('silo.views.appendTwoSilos')
     @patch('silo.views.MergedSilosFieldMapping')
-    def test_append(self, mock_merged_silos_map,
-                             mock_append_two_silos):
+    def test_append(self, mock_merged_silos_map, mock_append_two_silos):
         mock_append_two_silos.return_value = {'status': 'success'}
         mock_merged_silos_map.return_value = Mock()
 
@@ -634,11 +632,10 @@ class DoMergeViewTest(TestCase):
         request = self.factory.post('', data=data)
         request.user = self.tola_user.user
         response = views.do_merge(request)
-        content = json.loads(response.content)
 
         silo = Silo.objects.get(name=merged_silo_name)
-        self.assertEqual(content['status'], 'success')
-        self.assertIn('The merged table is accessible at', content['message'])
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/silo_detail/{}/'.format(silo.id))
         self.assertIn(left_read, silo.reads.all())
         self.assertIn(right_read, silo.reads.all())
 
@@ -729,8 +726,7 @@ class DoMergeViewTest(TestCase):
 
     @patch('silo.views.mergeTwoSilos')
     @patch('silo.views.MergedSilosFieldMapping')
-    def test_no_merge_name(self, mock_merged_silos_map,
-                                    mock_merge_two_silos):
+    def test_no_merge_name(self, mock_merged_silos_map, mock_merge_two_silos):
         mock_merge_two_silos.return_value = {'status': 'success'}
         mock_merged_silos_map.return_value = Mock()
 
@@ -759,10 +755,9 @@ class DoMergeViewTest(TestCase):
         request = self.factory.post('', data=data)
         request.user = self.tola_user.user
         response = views.do_merge(request)
-        content = json.loads(response.content)
 
         silo = Silo.objects.get(name=merged_silo_name)
-        self.assertEqual(content['status'], 'success')
-        self.assertIn('The merged table is accessible at', content['message'])
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/silo_detail/{}/'.format(silo.id))
         self.assertIn(left_read, silo.reads.all())
         self.assertIn(right_read, silo.reads.all())

--- a/silo/views.py
+++ b/silo/views.py
@@ -1360,9 +1360,8 @@ def do_merge(request):
                                       merged_silo=new_silo, mapping=data,
                                       merge_type=merge_type)
     mapping.save()
-    msg = 'The merged table is accessible at <a href="/silo_detail/{}/" ' \
-          'target="_blank">Merged Table</a>'.format(new_silo.pk)
-    return JsonResponse({'status': 'success', 'message': msg})
+    return HttpResponseRedirect(
+        reverse_lazy('siloDetail', kwargs={'silo_id': merge_table_id}))
 
 
 # EDIT A SINGLE VALUE STORE


### PR DESCRIPTION
## Purpose
When a user mergers two tables they stayed in the merge page but they should be redirected to the new table.

## Approach
Just added redirect the user to the silo detail page after the merging is done.

### Furter Info
Related ticket: #387 
