### PR TITLE
GSheet is aborted for first time users

### DIFF
--- a/silo/tests/test_gviews_v4.py
+++ b/silo/tests/test_gviews_v4.py
@@ -1,18 +1,22 @@
+import logging
 import json
 import os
-from unittest import TestCase as PythonTestCase
 import urllib
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from mock import patch
+from oauth2client.client import AccessTokenCredentialsError
+
+from rest_framework.test import APIRequestFactory
+from mock import Mock, patch
 
 import silo.gviews_v4 as gviews_v4
+import factories
 
 
-class GetOauthFlowTest(PythonTestCase):
+class GetOauthFlowTest(TestCase):
     @override_settings(GOOGLE_OAUTH_CLIENT_ID=None,
                        GOOGLE_OAUTH_CLIENT_SECRET=None)
     def test_get_oauth_flow_no_conf(self):
@@ -85,3 +89,68 @@ class GetCredentialObjectTest(TestCase):
         self.assertIn('access_type=offline', credential['redirect'])
         scope_url = urllib.quote_plus(gviews_v4.SCOPE)
         self.assertIn('scope={}'.format(scope_url), credential['redirect'])
+
+
+class OAuthTest(TestCase):
+    def setUp(self):
+        logging.disable(logging.ERROR)
+        
+        self.org = factories.Organization()
+        self.tola_user = factories.TolaUser(organization=self.org)
+        self.factory = APIRequestFactory()
+    
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def test_store_oauth2_credential_method_notallowed(self):
+        request = self.factory.get('')
+        request.user = self.tola_user.user
+        response = gviews_v4.store_oauth2_credential(request)
+
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response['Allow'], 'POST, OPTIONS')
+
+    @patch('silo.gviews_v4.OAuth2Credentials')
+    @patch('silo.gviews_v4.Storage')
+    def test_store_oauth2_credential_success_minimal(self, mock_storage,
+                                              mock_oauthcred):
+        mock_storage.return_value = Mock()
+        mock_oauthcred.return_value = Mock()
+        data = {
+            'access_token': 'mytestaccesstoken',
+        }
+        request = self.factory.post('', data=data)
+        request.user = self.tola_user.user
+        response = gviews_v4.store_oauth2_credential(request)
+        content = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content['detail'],
+                         'The credential was successfully saved.')
+
+    @patch('silo.gviews_v4.OAuth2Credentials')
+    @patch('silo.gviews_v4.Storage')
+    def test_store_oauth2_credential_success_full(self, mock_storage,
+                                              mock_oauthcred):
+        mock_storage.return_value = Mock()
+        mock_oauthcred.return_value = Mock()
+        data = {
+            'access_token': 'mytestaccesstoken',
+            'refresh_token': 'myrefreshtoken',
+            'expires_in': 3573,
+        }
+        request = self.factory.post('', data=data)
+        request.user = self.tola_user.user
+        response = gviews_v4.store_oauth2_credential(request)
+        content = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content['detail'],
+                         'The credential was successfully saved.')
+
+    def test_store_oauth2_credential_no_access_token(self):
+        request = self.factory.post('', {})
+        request.user = self.tola_user.user
+
+        with self.assertRaises(AccessTokenCredentialsError):
+            gviews_v4.store_oauth2_credential(request)

--- a/templates2/base.html
+++ b/templates2/base.html
@@ -268,9 +268,26 @@
 
             // After the authentication is complete, this method is called
             function handleAuthResult(authResult) {
+                /* Firefox issue with `g-oauth-window` attribute
+                 * Check stackoverflow answer
+                 * https://stackoverflow.com/questions/28949048/error-permission-denied-to-access-property-nodetype-on-ajax-request-in-firefo
+                 */
                 if (authResult && !authResult.error) {
-                    oauthToken = authResult.access_token;
-                    createPicker();
+                    url_credential = '{% url 'store_oauth2_credential' %}';
+                    delete authResult['g-oauth-window'];
+                    $.ajax({
+                        url: url_credential,
+                        type: "POST",
+                        headers: {'X-CSRFToken': getCookie('csrftoken')},
+                        data: authResult,
+                        success: function(data, textStatus, jqXHR) {
+                            oauthToken = authResult.access_token;
+                            createPicker();
+                        },
+                        error: function(jqXHR, textStatus, error) {
+                            console.log(jqXHR, textStatus, error);
+                        },
+                    });
                 }
             }
 

--- a/tola/urls.py
+++ b/tola/urls.py
@@ -85,6 +85,7 @@ urlpatterns =[
     url(r'^export_to_gsheet/(?P<id>\d+)/$', gviews_v4.export_to_gsheet, name='export_new_gsheet'),
     url(r'^export_to_gsheet/(?P<id>\d+)/$', gviews_v4.export_to_gsheet, name='export_existing_gsheet'),
     url(r'^oauth2callback/$', gviews_v4.oauth2callback, name='oauth2callback'),
+    url(r'^store_oauth2_credential/$', gviews_v4.store_oauth2_credential, name='store_oauth2_credential'),
     url(r'^import_gsheet/(?P<id>\d+)/$', gviews_v4.import_from_gsheet, name='import_gsheet'),
     url(r'^get_sheets_from_google_spreadsheet/$', gviews_v4.get_sheets_from_google_spreadsheet, name='get_sheets'),
 


### PR DESCRIPTION
## Purpose
GSheet import is aborted for first-time users

## Approach
The Google OAuth token wasn't being stored, so I created a view where we pass all the needed info and store them in the db.

### Furter Info
Related ticket: #313 
