### PR TITLE
Update the Logout URL to log out in Activity too

### DIFF
--- a/tola/tests/test_views.py
+++ b/tola/tests/test_views.py
@@ -1,4 +1,4 @@
-from django.test import Client, TestCase, RequestFactory
+from django.test import Client, override_settings, TestCase, RequestFactory
 from django.conf import settings
 from django.contrib import auth
 
@@ -126,6 +126,7 @@ class LogoutViewTest(TestCase):
         self.tola_user = factories.TolaUser(user=self.user)
         self.factory = RequestFactory()
 
+    @override_settings(ACTIVITY_URL='https://tolaactivity.com')
     def test_logout_redirect_logout_activity(self):
         c = Client()
         c.post('/accounts/login/', {'username': self.user.username,
@@ -138,14 +139,15 @@ class LogoutViewTest(TestCase):
         self.assertEqual(self.user.is_authenticated(), False)
         self.assertEqual(response.status_code, 302)
 
-        url_subpath = 'accounts/logout/'
-        redirect_url = urljoin(settings.TABLES_LOGIN_URL, url_subpath)
+        url_subpath = 'logout/'
+        redirect_url = urljoin(settings.ACTIVITY_URL, url_subpath)
         self.assertEqual(response.url, redirect_url)
 
+    @override_settings(ACTIVITY_URL='https://tolaactivity.com')
     def test_logout_redirect_to_activity(self):
         c = Client()
         response = c.post('/accounts/logout/')
         self.user = auth.get_user(c)
         self.assertEqual(self.user.is_authenticated(), False)
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, settings.TABLES_LOGIN_URL)
+        self.assertEqual(response.url, settings.ACTIVITY_URL)

--- a/tola/views.py
+++ b/tola/views.py
@@ -83,11 +83,11 @@ def logout_view(request):
     # be logged out there as well
     if request.user.is_authenticated:
         logout(request)
-        url_subpath = 'accounts/logout/'
-        url = urljoin(settings.TABLES_LOGIN_URL, url_subpath)
+        url_subpath = 'logout/'
+        url = urljoin(settings.ACTIVITY_URL, url_subpath)
         return HttpResponseRedirect(url)
 
-    return HttpResponseRedirect(settings.TABLES_LOGIN_URL)
+    return HttpResponseRedirect(settings.ACTIVITY_URL)
 
 
 class BoardView(LoginRequiredMixin, TemplateView):


### PR DESCRIPTION
## Purpose
When a user logs out from Track, that same user is not being logged out from Activity.

## Approach
We were sending the user to the Activity API logout but I updated the URL to send it to the application's logout.

### Open Questions and Pre-Merge TODOs
- [x] @wceolin has to check the logout endpoint in the app.

### Furter Info
Related ticket: #409 
