### PR TITLE
Fix issue with CeleryTask not existing when the task is executing

### DIFF
--- a/silo/views.py
+++ b/silo/views.py
@@ -850,11 +850,16 @@ def uploadFile(request, id):
             silo.reads.add(read_obj)
             silo_id = silo.id
 
+            task = CeleryTask.objects.create(task_id=None,
+                              task_status=None,
+                              content_object=read_obj)
+
             async_res = process_silo.apply_async(
                         (silo.id, read_obj.id)
             )
 
-            task = CeleryTask(task_id=async_res.id, task_status=CeleryTask.TASK_CREATED, content_object=read_obj)
+            task.task_id = async_res.id
+            task.task_status = CeleryTask.TASK_CREATED
             task.save()
 
             return HttpResponseRedirect('/silo_detail/' + str(silo_id) + '/')


### PR DESCRIPTION
## Purpose
Background import processes get stuck because the related `CeleryTask` object does not exist before creating the task. Apparently the task gets executed faster than the object is save to db.

## Approach
First create an empty `CeleryTask` object without information for the task in it. Then update it with the `task_id` after the task is created.