### PR TITLE
Add columns to the Silo endpoint

### DIFF
--- a/silo/api.py
+++ b/silo/api.py
@@ -282,16 +282,17 @@ class SiloViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         user_uuid = self.request.GET.get('user_uuid')
         if user_uuid is not None:
-            if TolaUser.objects.filter(tola_user_uuid=user_uuid).count() == 1:
-                tola_user = TolaUser.objects.prefetch_related('user').get(tola_user_uuid=user_uuid)
-                user = tola_user.user
-                return Silo.objects.filter(Q(owner=user) | Q(public=True) | Q(shared=user))
-            else:
+            try:
+                tola_user = TolaUser.objects.get(tola_user_uuid=user_uuid)
+            except TolaUser.DoesNotExist:
                 return Silo.objects.filter(owner=None)
+            else:
+                user = tola_user.user
+                return Silo.objects.filter(
+                    Q(owner=user) | Q(public=True) | Q(shared=user))
         else:
             user = self.request.user
             if user.is_superuser:
-                #pagination.PageNumberPagination.page_size = 200
                 return Silo.objects.all()
 
             return Silo.objects.filter(Q(owner=user) | Q(public=True))

--- a/silo/serializers.py
+++ b/silo/serializers.py
@@ -42,7 +42,9 @@ class SiloSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Silo
-        fields = ('owner', 'name', 'reads', 'description', 'create_date', 'id', 'data','shared','tags','public', 'data_count')
+        fields = ('owner', 'name', 'reads', 'description', 'create_date',
+                  'id', 'data', 'shared', 'tags', 'public', 'data_count',
+                  'columns')
         # removind depth for now, it may be breaking the post method
         # depth =1
 

--- a/silo/tests/test_siloview.py
+++ b/silo/tests/test_siloview.py
@@ -1,0 +1,79 @@
+from django.test import TestCase
+
+from rest_framework.test import APIRequestFactory
+
+import factories
+from silo.api import SiloViewSet
+
+
+class SiloListViewsTest(TestCase):
+    def setUp(self):
+        factories.Organization(id=1)
+        factories.Silo.create_batch(2)
+        self.factory = APIRequestFactory()
+        self.user = factories.User(first_name='Homer', last_name='Simpson')
+        self.tola_user = factories.TolaUser(user=self.user)
+
+    def test_list_silo_superuser(self):
+        request = self.factory.get('/api/silo/')
+        request.user = factories.User.build(is_superuser=True,
+                                            is_staff=True)
+        view = SiloViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+
+    def test_list_silo_normal_user(self):
+        request = self.factory.get('/api/silo/')
+        request.user = self.tola_user.user
+        view = SiloViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+        factories.Silo(owner=self.tola_user.user)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_list_silo_shared(self):
+        user = factories.User(first_name='Marge', last_name='Simpson')
+        factories.Silo(owner=user, shared=[self.user])
+
+        request = self.factory.get('/api/silo/?user_uuid={}'.format(
+            self.tola_user.tola_user_uuid))
+        request.user = self.tola_user.user
+        view = SiloViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+
+class SiloRetrieveViewsTest(TestCase):
+    def setUp(self):
+        factories.Organization(id=1)
+        self.silos = factories.Silo.create_batch(2)
+        self.factory = APIRequestFactory()
+        self.user = factories.User(first_name='Homer', last_name='Simpson')
+        self.tola_user = factories.TolaUser(user=self.user)
+
+    def test_retrieve_silo_superuser(self):
+        request = self.factory.get('/api/silo/')
+        request.user = factories.User.build(is_superuser=True,
+                                            is_staff=True)
+        view = SiloViewSet.as_view({'get': 'retrieve'})
+        response = view(request, id=self.silos[0].id)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['name'], self.silos[0].name)
+
+    def test_retrieve_silo_normal_user(self):
+        request = self.factory.get('/api/silo/')
+        request.user = self.tola_user.user
+        view = SiloViewSet.as_view({'get': 'retrieve'})
+        response = view(request, id=self.silos[0].id)
+        self.assertEqual(response.status_code, 404)
+
+        silo = factories.Silo(name='My Silo', owner=self.tola_user.user)
+        response = view(request, id=silo.id)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['name'], silo.name)


### PR DESCRIPTION
## Purpose
The users should be able to see the columns of the table in the silo endpoint. It'll be easier for the name to handle the data afterward.

## Approach
I only added the columns field to the serializer.

### Furter Info
Related ticket: #440 
