### PR TITLE
Small changes for cell edit crashing and type validation

### DIFF
--- a/silo/views.py
+++ b/silo/views.py
@@ -21,7 +21,6 @@ from django.http import HttpResponseBadRequest,\
 from django.shortcuts import render
 from django.utils import timezone
 from django.utils.encoding import smart_str, smart_text
-from django.utils.text import Truncator
 from django.db.models import Q
 from django.views.decorators.csrf import csrf_protect
 from django.contrib import messages
@@ -1436,7 +1435,6 @@ def valueEdit(request,id):
                 create_date = datetime.datetime.fromtimestamp(item['create_date']['$date']/1000)
                 data[k] = create_date.strftime('%Y-%m-%d')
             else:
-                k = Truncator(re.sub('\s+', ' ', k).strip()).chars(40)
                 data[k] = v
 
         keys = item.keys()

--- a/templates/display/silo.html
+++ b/templates/display/silo.html
@@ -159,7 +159,7 @@
                             <a href="/edit_columns/{{ silo.pk }}/" class="btn btn-primary">Edit or Delete columns</a>
                             <a href="/new_column/{{ silo.pk }}/" class="btn btn-primary">Add New Column</a>
                             <a href="/new_formula_column/{{ silo.pk }}/" class="btn btn-primary">Add New Formula Column</a>
-                            <button id="setColumnType" class="btn btn-primary" data-toggle="tooltip">Add Column Validation</button>
+                            <!-- <button id="setColumnType" class="btn btn-primary" data-toggle="tooltip">Add Column Validation</button> -->
 
                         <!--
                         <a href="/anonymize_silo/{{ id }}/" class="btn btn-primary">Anonymize Table</a>

--- a/templates/display/silo.html
+++ b/templates/display/silo.html
@@ -159,7 +159,6 @@
                             <a href="/edit_columns/{{ silo.pk }}/" class="btn btn-primary">Edit or Delete columns</a>
                             <a href="/new_column/{{ silo.pk }}/" class="btn btn-primary">Add New Column</a>
                             <a href="/new_formula_column/{{ silo.pk }}/" class="btn btn-primary">Add New Formula Column</a>
-                            <!-- <button id="setColumnType" class="btn btn-primary" data-toggle="tooltip">Add Column Validation</button> -->
 
                         <!--
                         <a href="/anonymize_silo/{{ id }}/" class="btn btn-primary">Anonymize Table</a>
@@ -589,7 +588,7 @@
                     type: "PATCH",
                     data: data,
                     success: function(data, textStatus, jqXHR) {
-                        alert("Your change was successful.");                      
+                        alert("Your change was successful.");
                     },
                     error: function(jqXHR, textStatus, error) {
                         alert("error\n"+error);


### PR DESCRIPTION
## Purpose
Issues #360 and #305

## Approach
For #360, removed the truncation of names completely.  If truncated names are needed, a more robust solution will need to be used.

For #305, hid the validation button, because the functionality is not yet working.  Left the javascript code in to allow someone to finish the feature in the future.

### Furter Info
@menda may want to review
