### PR TITLE
Fix JSON encoder

### DIFF
--- a/tola/tests/test_util.py
+++ b/tola/tests/test_util.py
@@ -22,3 +22,8 @@ class RegisterViewTest(TestCase):
 
         encoded = JSONEncoder().encode(dict_test)
         self.assertTrue(isinstance(encoded, str))
+        self.assertEqual(encoded, '{"silo_id": 2, "read_id": 2, "county": '
+                                  '"CLAY COUNTY", "tiv_2011": 60946.79, '
+                                  '"statecode": "FL", "_id": {"$oid": '
+                                  '"5aaf820a58d8e7002c889905"}, "policy_id": '
+                                  '353022}')

--- a/tola/util.py
+++ b/tola/util.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("tola")
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, ObjectId):
-            return str(o)
+            return {u'$oid': str(o)}
         return json.JSONEncoder.default(self, o)
 
 


### PR DESCRIPTION
## Purpose
I had to fix the JSON encoder because it was returning a wrong value for the `_id`

### Furter Info
Related ticket: #444 
