### PR TITLE
Closes #246, values of newly imported data are now stripped of whitespaces

### DIFF
--- a/silo/gviews_v4.py
+++ b/silo/gviews_v4.py
@@ -187,7 +187,7 @@ def import_from_gsheet_helper(user, silo_id, silo_name, spreadsheet_id, sheet_id
         # build filter_criteria if unique field(s) have been setup for this silo
         for unique_field in unique_fields:
             try:
-                filter_criteria.update({unique_field.name: row[headers.index(unique_field.name)]})
+                filter_criteria.update({unique_field.name: row[headers.index(unique_field.name)].strip()})
             except KeyError:
                 pass
             except ValueError:
@@ -215,10 +215,7 @@ def import_from_gsheet_helper(user, silo_id, silo_name, spreadsheet_id, sheet_id
             except IndexError as e:
                 #this happens when a column header is missing gsheet
                 continue
-            if key == "" or key is None or key == "silo_id": continue
-            elif key == "id" or key == "_id": key = "user_assigned_id"
-            elif key == "edit_date": key = "editted_date"
-            elif key == "create_date": key = "created_date"
+            key = cleanKey(key)
             val = smart_str(row[c], strings_only=True)
             key = smart_str(key)
             val = val.strip()

--- a/silo/gviews_v4.py
+++ b/silo/gviews_v4.py
@@ -219,7 +219,7 @@ def import_from_gsheet_helper(user, silo_id, silo_name, spreadsheet_id, sheet_id
             val = smart_str(row[c], strings_only=True)
             key = smart_str(key)
             val = val.strip()
-            setattr(lvs, key.replace(".", "_").replace("$", "USD"), val)
+            setattr(lvs, key, val)
         lvs.silo_id = silo.id
         lvs.read_id = gsheet_read.id
         lvs.create_date = timezone.now()

--- a/silo/management/commands/stripMongoData.py
+++ b/silo/management/commands/stripMongoData.py
@@ -1,0 +1,112 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.encoding import smart_text, smart_str
+from django.conf import settings
+import pymongo
+from bson.objectid import ObjectId
+import json
+import random
+from silo.models import LabelValueStore, Silo
+
+
+class Command(BaseCommand):
+    """
+    Usage: python manage.py update_to_0-9-2
+    """
+    def add_arguments(self, parser):
+        parser.add_argument("--write", action='store_true', dest='write')
+
+    def handle(self, *args, **options):
+
+        client  = pymongo.MongoClient(settings.MONGODB_URI)
+        db = client.get_database(settings.TOLATABLES_MONGODB_NAME)
+
+        counter = 0
+        foundSilos = set()
+        recordsUpdated = []
+        multiMod = []
+
+        # sampleRecords = db.label_value_store.find({"silo_id": {"$in": [175, 891, 996, 981, 1342, 1576]}})
+        # print sampleRecords.count()
+        # for r in sampleRecords:
+        #     print 's=', r['silo_id']
+        # import sys
+        # print 'done'
+        # sys.exit()
+
+        autoPushEnabled = list(Silo.objects.filter(reads__autopush_frequency__isnull=False).values_list('pk', flat=True))
+        problemSilos = {}
+        diffSamples = []
+        diffInclude = ['5731956873abe223358d3a74', '57a473d005e48c0fdd83cdb8']
+        rCountBefore = db.label_value_store.count()
+
+        for record in db.label_value_store.find({}):
+            for key in record:
+                try:
+                    newVal = record[key].strip()
+                except:
+                    continue
+                # print 'new', newVal
+                # print '|val=%s newval=%s' % (record[key], newVal)
+                if newVal != record[key]:
+                    # print all diffs to console and save some samples for later
+                    diff = 'silo %s: different new=|%s| old=|%s|, key=%s, _id=%s' % \
+                        (record['silo_id'],
+                        smart_str(newVal),
+                        smart_str(record[key]),
+                        smart_str(key),
+                        record['_id'])
+                    print diff
+                    if (random.random() > .99 and len(diffSamples) <=15) \
+                            or str(record['_id']) in diffInclude:
+                        diffSamples.append(diff)
+
+                    # There could be problems with the GSheet data if the auto-push
+                    # has already taken place.  This lets us highlight potential problems
+                    if record['silo_id'] in autoPushEnabled:
+                        try:
+                            problemSilos[record['silo_id']].append(key)
+                        except KeyError:
+                            problemSilos[record['silo_id']] = [key]
+                    foundSilos.add(record['silo_id'])
+
+                    # Only perform the update if the --write flag is thrown
+                    if options['write']:
+                        rid = ObjectId(record['_id'])
+                        result = db.label_value_store.update_one(
+                                        {'_id': rid},
+                                        {'$set': {key : newVal}}
+                                    )
+
+                        # Hightlight any places where we updated more than one record
+                        if result.matched_count > 1:
+                            multiMod.append((rid, key))
+
+                        recordsUpdated.append({
+                            'mongo_id': record['_id']
+                        })
+
+
+            counter += 1
+            # if counter >= 50000:
+            #     break
+
+        print '\n#########################################'
+        print '#########################################'
+        print ''
+        print '\nDiff samples:'
+        print '\n'.join(diffSamples)
+        print ''
+        print 'Records count before', rCountBefore
+        print 'Records count after', db.label_value_store.count()
+        print '\n%s records examined\n' % counter
+        print '%s silos with extra whitespace:' % len(foundSilos)
+        print ', '.join(sorted([str(i) for i in foundSilos]))
+        print '\nMultimods (hopefully empty):', multiMod
+        print ''
+        print '%s records updated.  If value is 0 you may not have used the --write option.\n' % len(recordsUpdated)
+        if len(problemSilos) > 0:
+            print "These silos had extra whitespace and are on the auto-push list:"
+            for silo in problemSilos:
+                print 'silo_id %s: %s' % (silo, ', '.join(problemSilos[silo]))
+        else:
+            print "There were no silos that had extra whitespace and that were auto-push"


### PR DESCRIPTION

## Purpose
Closes #246, values of newly imported data are now stripped of leading and trailing whitespaces before being matched to values in the Mongo DB.

- Stripping of whitespace on data import was implemented in a prior commit.  Without this change,     when header values in the database are compared to newly imported values, they will not match even though they should. This primarily affects tables with unique columns designated and can result in duplicated data in the table.
- Added a management script that strips all whitespace at the begging and end of each value from existing data stored in Mongo DB.  Logging information is printed to STDOUT. 

## Approach
See above

### Further Info
@Menda 

Related ticket: #246 
