### PR TITLE
Fix out of range error in the silo data view

### DIFF
--- a/silo/api.py
+++ b/silo/api.py
@@ -332,8 +332,12 @@ class SiloViewSet(viewsets.ReadOnlyModelViewSet):
 
         count_pipeline = pipeline + [{'$count': 'count'}]
         count_cur = collection.aggregate(pipeline=count_pipeline)
-        count_result = list(count_cur)[0]
-        records_total = count_result['count']
+        list_count = list(count_cur)
+        if list_count:
+            count_result = list_count[0]
+            records_total = count_result['count']
+        else:
+            records_total = 0
 
         # workaround until the problem of javascript not increasing
         # the value of length is fixed

--- a/silo/tests/test_siloview.py
+++ b/silo/tests/test_siloview.py
@@ -117,6 +117,19 @@ class SiloDataViewTest(TestCase):
         self.assertEqual(json_content['recordsTotal'], 20)
         self.assertEqual(json_content['recordsFiltered'], 20)
 
+    def test_data_silo_empty_table(self):
+        read = factories.Read(read_name="test_empty", owner=self.tola_user.user)
+        silo = factories.Silo(owner=self.tola_user.user, reads=[read])
+
+        request = self.factory.get('/api/silo/{}/data'.format(silo.id))
+        request.user = self.tola_user.user
+        view = SiloViewSet.as_view({'get': 'data'})
+        response = view(request, id=silo.id)
+        self.assertEqual(response.status_code, 200)
+        json_content = json.loads(response.content)
+        self.assertEqual(json_content['recordsTotal'], 0)
+        self.assertEqual(json_content['recordsFiltered'], 0)
+
     def test_data_silo_query(self):
         query = '{"opn": "2015-11"}'
         request = self.factory.get('/api/silo/{}/data?query={}'.format(


### PR DESCRIPTION
## Purpose
Fix the out of range error when fetching table without data.

### Furter Info
Related ticket: #449 
