### PR TITLE
The import functionality shouldn't import everything as string

### DIFF
--- a/datasources/commcare/util.py
+++ b/datasources/commcare/util.py
@@ -9,7 +9,7 @@ from celery import group
 from .tasks import fetchCommCareData, requestCommCareData, storeCommCareData
 
 from silo.models import LabelValueStore
-from tola.util import saveDataToSilo, addColsToSilo, hideSiloColumns
+from tola.util import save_data_to_silo, addColsToSilo, hideSiloColumns
 from pymongo import MongoClient
 from django.conf import settings
 

--- a/datasources/commcare/views.py
+++ b/datasources/commcare/views.py
@@ -6,7 +6,7 @@ from requests.auth import HTTPDigestAuth
 from django.http import HttpResponseRedirect, HttpResponseBadRequest, HttpResponse
 
 
-from tola.util import saveDataToSilo, getSiloColumnNames
+from tola.util import getSiloColumnNames
 from django.shortcuts import redirect, render
 from django.core.urlresolvers import reverse, reverse_lazy
 

--- a/datasources/fileuploadjson/views.py
+++ b/datasources/fileuploadjson/views.py
@@ -6,7 +6,7 @@ import datetime
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 from django.shortcuts import render
-from tola.util import saveDataToSilo
+from tola.util import save_data_to_silo
 from django.core.urlresolvers import reverse, reverse_lazy
 
 from django.contrib import messages
@@ -61,7 +61,7 @@ def file(request, id):
             silo.reads.add(read_obj)
             silo_id = silo.id
             data = json.load(read_obj.file_data)
-            saveDataToSilo(silo, data, read_obj)
+            save_data_to_silo(silo, data, read_obj)
             return HttpResponseRedirect('/silo_detail/%s/' % silo_id)
             # except Exception as e:
             #     messages.error(request, "Your JSON file was formatted incorrectly")

--- a/factories/silo_models.py
+++ b/factories/silo_models.py
@@ -6,6 +6,7 @@ from factory import (DjangoModelFactory, LazyAttribute, SubFactory,
                      post_generation, Iterator)
 
 from silo.models import (
+    CeleryTask as CeleryTaskM,
     Country as CountryM,
     LabelValueStore as LabelValueStoreM,
     Organization as OrganizationM,
@@ -16,8 +17,8 @@ from silo.models import (
     ThirdPartyTokens as ThirdPartyTokensM,
     TolaSites as TolaSitesM,
     TolaUser as TolaUserM,
-    WorkflowLevel1 as WorkflowLevel1M,
-    CeleryTask as CeleryTaskM
+    UniqueFields as UniqueFieldsM,
+    WorkflowLevel1 as WorkflowLevel1M
 )
 from .user_models import User
 
@@ -164,6 +165,14 @@ class Silo(DjangoModelFactory):
             # A list of formulacolumns were passed in, use them
             for formulacolumns in extracted:
                 self.formulacolumns.add(formulacolumns)
+
+
+class UniqueFields(DjangoModelFactory):
+    class Meta:
+        model = UniqueFieldsM
+
+    name = 'Test'
+    silo = SubFactory(Silo)
 
 
 class LabelValueStore(DjangoModelFactory):

--- a/silo/api.py
+++ b/silo/api.py
@@ -22,7 +22,7 @@ from .models import (Silo, LabelValueStore, Country, WorkflowLevel1,
                      WorkflowLevel2, TolaUser, Read, ReadType)
 from silo.permissions import *
 from tola.util import (getSiloColumnNames, getCompleteSiloColumnNames,
-                       saveDataToSilo, JSONEncoder)
+                       save_data_to_silo, JSONEncoder)
 
 
 class TolaUserViewSet(viewsets.ModelViewSet):
@@ -250,7 +250,7 @@ class CustomFormViewSet(mixins.CreateModelMixin,
             return Response({'detail': 'Not found.'},
                             status=status.HTTP_404_NOT_FOUND)
         else:
-            saveDataToSilo(silo, [data], silo.reads.first())
+            save_data_to_silo(silo, [data], silo.reads.first())
             return Response({'detail': 'It was successfully saved.'},
                             status=status.HTTP_200_OK)
 

--- a/silo/management/commands/get_all_ona_forms.py
+++ b/silo/management/commands/get_all_ona_forms.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import MultipleObjectsReturned
 
 from silo.models import LabelValueStore, Read, ReadType, Silo, ThirdPartyTokens
-from tola.util import  saveDataToSilo
+from tola.util import  save_data_to_silo
 
 class Command(BaseCommand):
     """
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                 data = json.loads(response.content)
 
                 try:
-                    saveDataToSilo(silo, data, read, silo.owner.pk)
+                    save_data_to_silo(silo, data, read, silo.owner.pk)
                     self.stdout.write('Successfully fetched the READ_ID, "%s", from ONA' % read.pk)
                 except TypeError as e:
                     self.logger.error("type error: silo_id=%s, read_id=%s" % (silo.pk, read.pk))

--- a/silo/management/commands/get_ona_form_data.py
+++ b/silo/management/commands/get_ona_form_data.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from django.contrib.auth.models import User
 
 from silo.models import LabelValueStore, Read, Silo, ThirdPartyTokens
-from tola.util import  saveDataToSilo
+from tola.util import save_data_to_silo
 
 class Command(BaseCommand):
     """
@@ -42,5 +42,5 @@ class Command(BaseCommand):
             ona_token = ThirdPartyTokens.objects.get(user=user.pk, name="ONA")
             response = requests.get(read.read_url, headers={'Authorization': 'Token %s' % ona_token.token})
             data = json.loads(response.content)
-            saveDataToSilo(silo, data, read, user)
+            save_data_to_silo(silo, data, read, user)
             self.stdout.write('Successfully fetched the READ_ID, "%s", from database' % read_id)

--- a/silo/tasks.py
+++ b/silo/tasks.py
@@ -1,17 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 from celery import shared_task
-from celery.result import AsyncResult
-from tola.celery import app
 
 from silo.custom_csv_dict_reader import CustomDictReader
-from tola.util import saveDataToSilo
+from tola.util import save_data_to_silo
 from .models import Silo, Read, CeleryTask
 
 from django.contrib.contenttypes.models import ContentType
 
 import logging
 
-logger = logging.getLogger("tola")
+logger = logging.getLogger(__name__)
 
 
 @shared_task(bind=True, retry=False)
@@ -26,7 +24,7 @@ def process_silo(self, silo_id, read_id):
 
     try:
         reader = CustomDictReader(read_obj.file_data)
-        saveDataToSilo(silo, reader, read_obj)
+        save_data_to_silo(silo, reader, read_obj)
         task.task_status = CeleryTask.TASK_FINISHED
     except TypeError, e:
         logger.error(e)

--- a/silo/tests/sample_data/import_json.json
+++ b/silo/tests/sample_data/import_json.json
@@ -2,7 +2,7 @@
 	"nm": "Edmund lronside",
 	"cty": "United Kingdom",
 	"hse": "House of Wessex",
-	"yrs": "1016"
+	"yrs": 1016
 }, {
 	"nm": "Cnut",
 	"cty": "United Kingdom",
@@ -27,7 +27,7 @@
 	"nm": "Harold II",
 	"cty": "United Kingdom",
 	"hse": "House of Wessex",
-	"yrs": "1066"
+	"yrs": 1066
 }, {
 	"nm": "William I",
 	"cty": "United Kingdom",
@@ -112,7 +112,7 @@
 	"nm": "Edward V",
 	"cty": "United Kingdom",
 	"hse": "House of York",
-	"yrs": "1483"
+	"yrs": 1483
 }, {
 	"nm": "Richard III",
 	"cty": "United Kingdom",
@@ -232,7 +232,7 @@
 	"nm": "Edward VIII",
 	"cty": "United Kingdom",
 	"hse": "House of Windsor",
-	"yrs": "1936"
+	"yrs": 1936
 }, {
 	"nm": "George VI",
 	"cty": "United Kingdom",

--- a/silo/tests/test.py
+++ b/silo/tests/test.py
@@ -12,7 +12,8 @@ from commcare.tasks import parseCommCareData
 from commcare.util import getProjects
 from silo.tasks import process_silo
 from silo.forms import get_read_form
-from silo.models import DeletedSilos, LabelValueStore, ReadType, Read, Silo, CeleryTask
+from silo.models import (DeletedSilos, LabelValueStore, ReadType, Read, Silo,
+                         CeleryTask)
 from silo.views import (addColumnFilter, editColumnOrder, newFormulaColumn,
                         showRead, editSilo, uploadFile, siloDetail)
 from tola.util import (addColsToSilo, hideSiloColumns, getColToTypeDict,
@@ -23,14 +24,14 @@ from django.utils.encoding import smart_str
 
 from mock import patch
 from celery.exceptions import Retry
-import time
 import factories
 
 
 class UploadFileTest(TestCase):
     """
     Tests the File Upload Process in several steps.
-    - Checks if uploadFile successfully creates a celery task and new silo for imported read
+    - Checks if uploadFile successfully creates a celery task and new silo
+    for imported read
     - Checks if process_silo actually imports data
     - Checks what happens if the task fails
 
@@ -44,7 +45,8 @@ class UploadFileTest(TestCase):
 
     def test_upload_file(self):
         """
-        Checks if uploadFile successfully creates a celery task and new silo for imported read
+        Checks if uploadFile successfully creates a celery task and new silo
+        for imported read
 
         uploadFile takes POST request with csv file
         - takes a Read
@@ -94,13 +96,18 @@ class UploadFileTest(TestCase):
 
         read_type = factories.ReadType(read_type="CSV")
         upload_file = open('silo/tests/sample_data/test.csv', 'rb')
-        read = factories.Read(owner=self.user, type=read_type, file_data=SimpleUploadedFile(upload_file.name, upload_file.read()))
+        read = factories.Read(
+            owner=self.user, type=read_type,
+            file_data=SimpleUploadedFile(upload_file.name, upload_file.read())
+        )
 
-        task = factories.CeleryTask(task_status=CeleryTask.TASK_CREATED, content_object=read)
+        factories.CeleryTask(task_status=CeleryTask.TASK_CREATED,
+                             content_object=read)
 
         process_done = process_silo(silo.id, read.id)
-
-        self.assertEqual(getSiloColumnNames(silo.id), ['First_Name', 'Last_Name', 'E-mail'])
+        silo = Silo.objects.get(pk=silo.id)
+        self.assertEqual(getSiloColumnNames(silo.id),
+                         ['First_Name', 'Last_Name', 'E-mail'])
         self.assertTrue(process_done)
 
     def test_celery_failure(self):
@@ -108,7 +115,10 @@ class UploadFileTest(TestCase):
 
         read_type = factories.ReadType(read_type="CSV")
         upload_file = open('silo/tests/sample_data/test_broken.csv', 'rb')
-        read = factories.Read(owner=self.user, type=read_type, file_data=SimpleUploadedFile(upload_file.name, upload_file.read()))
+        read = factories.Read(
+            owner=self.user, type=read_type,
+            file_data=SimpleUploadedFile(upload_file.name, upload_file.read())
+        )
         task = factories.CeleryTask(content_object=read)
 
         process_silo(silo.id, read.id)
@@ -133,7 +143,8 @@ class UploadFileTest(TestCase):
 class SiloDetailTest(TestCase):
     """
     Test Silo Detail in the following scenarios
-    1 - CeleryTask running in the background: no data is shown and info is displayed
+    1 - CeleryTask running in the background: no data is shown and info
+        is displayed
     2 - CeleryTask Finished: data is shown
     3 - CeleryTask Failed: data is shown and error message is displayed
     """
@@ -154,7 +165,8 @@ class SiloDetailTest(TestCase):
         )
         silo = factories.Silo(owner=self.user, public=False)
         silo.reads.add(read)
-        task = factories.CeleryTask(content_object=read, task_status=CeleryTask.TASK_IN_PROGRESS)
+        factories.CeleryTask(content_object=read,
+                             task_status=CeleryTask.TASK_IN_PROGRESS)
 
         # Check view
 
@@ -162,9 +174,16 @@ class SiloDetailTest(TestCase):
         request.user = self.user
 
         response = siloDetail(request, silo.pk)
-        self.assertContains(response, "<a href=\"/show_read/"+str(read.id)+"\" target=\"_blank\">"+read.read_name+"</a>")
-        self.assertContains(response, "<span class=\"btn-sm btn-warning\">Import running</span>")
-        self.assertContains(response, "<h4>Import process running</h4>")
+        self.assertContains(
+            response,
+            '<a href="/show_read/{}" target="_blank">{}</a>'.format(
+                read.id, read.read_name)
+        )
+        self.assertContains(
+            response,
+            '<span class="btn-sm btn-warning">Import running</span>'
+        )
+        self.assertContains(response, '<h4>Import process running</h4>')
 
     def test_silo_detail_import_failed(self):
         # Create Silo, Read and CeleryTask
@@ -175,16 +194,25 @@ class SiloDetailTest(TestCase):
         )
         silo = factories.Silo(owner=self.user, public=False)
         silo.reads.add(read)
-        task = factories.CeleryTask(content_object=read, task_status=CeleryTask.TASK_FAILED)
+        factories.CeleryTask(content_object=read,
+                             task_status=CeleryTask.TASK_FAILED)
 
         # Check view
         request = self.factory.get(self.silo_detail_url)
         request.user = self.user
 
         response = siloDetail(request, silo.pk)
-        self.assertContains(response, "<a href=\"/show_read/"+str(read.id)+"\" target=\"_blank\">"+read.read_name+"</a>")
-        self.assertContains(response, "<span class=\"btn-sm btn-danger\">Import Failed</span>")
-        self.assertContains(response, "<h4 style=\"color:#ff3019\">Import process failed</h4>")
+        self.assertContains(
+            response,
+            '<a href="/show_read/{}" target="_blank">{}</a>'.format(
+                read.id, read.read_name)
+        )
+        self.assertContains(
+            response,
+            '<span class="btn-sm btn-danger">Import Failed</span>'
+        )
+        self.assertContains(
+            response, '<h4 style="color:#ff3019">Import process failed</h4>')
 
     def test_silo_detail_import_done(self):
         # Create Silo, Read and CeleryTask
@@ -195,18 +223,26 @@ class SiloDetailTest(TestCase):
         )
         silo = factories.Silo(owner=self.user, public=False)
         silo.reads.add(read)
-        task = factories.CeleryTask(content_object=read, task_status=CeleryTask.TASK_FINISHED)
+        factories.CeleryTask(content_object=read,
+                             task_status=CeleryTask.TASK_FINISHED)
 
         # Check view
         request = self.factory.get(self.silo_detail_url)
         request.user = self.user
 
         response = siloDetail(request, silo.pk)
-        self.assertContains(response, "<a href=\"/show_read/"+str(read.id)+"\" target=\"_blank\">"+read.read_name+"</a>")
-        self.assertNotContains(response, "<span class=\"btn-sm btn-danger\">Import Failed</span>")
-        self.assertNotContains(response, "<span class=\"btn-sm btn-warning\">Import running</span>")
-        self.assertNotContains(response, "<h4 style=\"color:#ff3019\">Import process failed</h4>")
-        self.assertNotContains(response, "<h4>Import process running</h4>")
+        self.assertContains(
+            response,
+            '<a href="/show_read/{}" target="_blank">{}</a>'.format(
+                read.id, read.read_name)
+        )
+        self.assertNotContains(
+            response, '<span class="btn-sm btn-danger">Import Failed</span>')
+        self.assertNotContains(
+            response, '<span class="btn-sm btn-warning">Import running</span>')
+        self.assertNotContains(
+            response, '<h4 style="color:#ff3019">Import process failed</h4>')
+        self.assertNotContains(response, '<h4>Import process running</h4>')
 
 
 class ReadTest(TestCase):
@@ -244,7 +280,7 @@ class ReadTest(TestCase):
         else:
             self.assertEqual(response.status_code, 200)
 
-        # Now test the show_read view to make sure that I can retrieve the objec
+        # Now test the show_read view to make sure that I can retrieve the obj
         # that just got created using the POST method above.
         source = Read.objects.get(read_name='TEST READ SOURCE')
         response = self.client.get(self.show_read_url + str(source.pk) + "/")
@@ -844,7 +880,8 @@ class TestCleanKeys(TestCase):
         lvs.silo_id = self.silo.id
         lvs.save()
 
-        returned_data = json.loads(LabelValueStore.objects(silo_id=self.silo.id).to_json())[0]
+        returned_data = json.loads(LabelValueStore.objects(
+            silo_id=self.silo.id).to_json())[0]
         returned_data.pop('_id')
 
         expected_data = {

--- a/silo/tests/test_gviews_v4.py
+++ b/silo/tests/test_gviews_v4.py
@@ -3,17 +3,21 @@ import json
 import os
 import urllib
 
+from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from oauth2client.client import AccessTokenCredentialsError
+from oauth2client.client import (AccessTokenCredentialsError,
+                                 HttpAccessTokenRefreshError, OAuth2Credentials)
 
 from rest_framework.test import APIRequestFactory
 from mock import Mock, patch
 
 import silo.gviews_v4 as gviews_v4
 import factories
+from tola.util import save_data_to_silo
+from silo.models import LabelValueStore, Silo
 
 
 class GetOauthFlowTest(TestCase):
@@ -154,3 +158,470 @@ class OAuthTest(TestCase):
 
         with self.assertRaises(AccessTokenCredentialsError):
             gviews_v4.store_oauth2_credential(request)
+
+
+class ImportFromGSheetHelperTest(TestCase):
+    def setUp(self):
+        self.org = factories.Organization()
+        self.tola_user = factories.TolaUser(organization=self.org)
+        self.read = factories.Read(read_name='Test Read')
+        self.silo = factories.Silo(reads=[self.read])
+
+    def tearDown(self):
+        # Have to remove the created lvs
+        lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
+        for lvs in lvss:
+            lvs.delete()
+
+    @patch('silo.gviews_v4._get_or_create_read')
+    @patch('silo.gviews_v4._fetch_data_gsheet')
+    @patch('silo.gviews_v4._get_gsheet_metadata')
+    @patch('silo.gviews_v4._get_authorized_service')
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_import_from_gsheet_helper_minimal(
+            self, mock_get_credential_obj, mock_get_authorized_service,
+            mock_get_gsheet_metadata, mock_fetch_data_gsheet,
+            mock_get_or_create_read):
+        data = [
+            ['Name', 'Age'],
+            ['John', '40'],
+        ]
+        expected_result = [
+            {'silo_id': self.silo.id},
+            {'msg': 'Operation successful', 'level': messages.SUCCESS}
+        ]
+
+        mock_get_credential_obj.return_value = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        mock_get_gsheet_metadata.return_value = (Mock(), None)
+        mock_fetch_data_gsheet.return_value = (data, None)
+        mock_get_or_create_read.return_value = self.read
+
+        result = gviews_v4.import_from_gsheet_helper(
+            self.tola_user.user, self.silo.id, self.silo.name, 1234)
+
+        self.silo = Silo.objects.get(id=self.silo.id)
+        self.assertEqual(result, expected_result)
+
+        lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
+        for lvs in lvss:
+            lvs_json = json.loads(lvs.to_json())
+            self.assertEqual(lvs_json.get('Name'), 'John')
+            self.assertEqual(lvs_json.get('Age'), 40)
+
+    @patch('silo.gviews_v4._get_gsheet_metadata')
+    @patch('silo.gviews_v4._get_authorized_service')
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_import_from_gsheet_helper_sheet_not_selected(
+            self, mock_get_credential_obj, mock_get_authorized_service,
+            mock_get_gsheet_metadata):
+        external_msg = {
+            'level': messages.ERROR,
+            'msg': 'Error: GSheet is not selected.'
+        }
+        expected_result = [
+            {
+                'level': messages.ERROR,
+                'msg': 'A Google Spreadsheet is not selected to '
+                       'import data from.',
+                'redirect': reverse('index')
+            },
+            {'silo_id': self.silo.id},
+            external_msg
+        ]
+
+        mock_get_credential_obj.return_value = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        mock_get_gsheet_metadata.return_value = (None, external_msg)
+
+        result = gviews_v4.import_from_gsheet_helper(
+            self.tola_user.user, self.silo.id, self.silo.name, None)
+
+        self.assertEqual(result, expected_result)
+
+    @patch('silo.gviews_v4._get_gsheet_metadata')
+    @patch('silo.gviews_v4._get_authorized_service')
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_import_from_gsheet_helper_sheet_refresh_credential(
+            self, mock_get_credential_obj, mock_get_authorized_service,
+            mock_get_gsheet_metadata):
+        mock_credential_obj = Mock(OAuth2Credentials)
+        external_msg = {
+            'credential': [mock_credential_obj],
+        }
+
+        mock_get_credential_obj.return_value = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        mock_get_gsheet_metadata.return_value = (None, external_msg)
+
+        result = gviews_v4.import_from_gsheet_helper(
+            self.tola_user.user, self.silo.id, self.silo.name, None)
+
+        self.assertEqual(result, [mock_credential_obj])
+
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_import_from_gsheet_helper_wrong_creadential(
+            self, mock_get_credential_obj):
+        msg = {
+            'msg': 'Requires Google Authorization Setup',
+            'redirect': 'url',
+            'redirect_uri_after_step2': True,
+            'level': messages.ERROR
+        }
+        mock_get_credential_obj.return_value = msg
+
+        result = gviews_v4.import_from_gsheet_helper(
+            self.tola_user.user, self.silo.id, self.silo.name, 1234)
+        self.assertEqual(result, [msg])
+
+    @patch('silo.gviews_v4._get_or_create_read')
+    @patch('silo.gviews_v4._fetch_data_gsheet')
+    @patch('silo.gviews_v4._get_gsheet_metadata')
+    @patch('silo.gviews_v4._get_authorized_service')
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_import_from_gsheet_helper_error_fetching(
+            self, mock_get_credential_obj, mock_get_authorized_service,
+            mock_get_gsheet_metadata, mock_fetch_data_gsheet,
+            mock_get_or_create_read):
+        external_msg = {
+            'level': messages.ERROR,
+            'msg': 'Something went wrong 22: error',
+            'redirect': None
+        }
+        expected_result = [
+            {'silo_id': self.silo.id},
+            external_msg
+        ]
+
+        mock_get_credential_obj.return_value = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        mock_get_gsheet_metadata.return_value = (Mock(), None)
+        mock_fetch_data_gsheet.return_value = (None, external_msg)
+        mock_get_or_create_read.return_value = self.read
+
+        result = gviews_v4.import_from_gsheet_helper(
+            self.tola_user.user, self.silo.id, self.silo.name, 1234)
+        self.assertEqual(result, expected_result)
+
+    @patch('silo.gviews_v4._get_or_create_read')
+    @patch('silo.gviews_v4._fetch_data_gsheet')
+    @patch('silo.gviews_v4._get_gsheet_metadata')
+    @patch('silo.gviews_v4._get_authorized_service')
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_import_from_gsheet_helper_unique_fields(
+            self, mock_get_credential_obj, mock_get_authorized_service,
+            mock_get_gsheet_metadata, mock_fetch_data_gsheet,
+            mock_get_or_create_read):
+        lvs = LabelValueStore()
+        lvs.silo_id = self.silo.id
+        lvs.save()
+        data = [{
+            'First.Name': 'John',
+            'Last.Name': 'Doe',
+            'E-mail': 'john@example.org',
+        }, {
+            'First.Name': 'Bob',
+            'Last.Name': 'Smith',
+            'E-mail': 'bob@example.org',
+        }]
+
+        save_data_to_silo(self.silo, data, self.read)
+        factories.UniqueFields(name='E-mail', silo=self.silo)
+
+        data = [
+            ['First.Name', 'Last.Name', 'E-mail'],
+            ['John', 'Lennon', 'john@example.org'],
+        ]
+        expected_result = [
+            {'silo_id': self.silo.id},
+            {'msg': 'Operation successful', 'level': messages.SUCCESS}
+        ]
+
+        mock_get_credential_obj.return_value = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        mock_get_gsheet_metadata.return_value = (Mock(), None)
+        mock_fetch_data_gsheet.return_value = (data, None)
+        mock_get_or_create_read.return_value = self.read
+
+        result = gviews_v4.import_from_gsheet_helper(
+            self.tola_user.user, self.silo.id, self.silo.name, 1234)
+        self.assertEqual(result, expected_result)
+
+        lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
+        count = 0
+        for lvs in lvss:
+            lvs_json = json.loads(lvs.to_json())
+            if lvs_json.get('First_Name') == 'John':
+                self.assertEqual(lvs_json.get('Last_Name'), 'Lennon')
+                count += 1
+
+        self.assertEqual(count, 1)
+
+    @patch('silo.gviews_v4._get_or_create_read')
+    @patch('silo.gviews_v4._fetch_data_gsheet')
+    @patch('silo.gviews_v4._get_gsheet_metadata')
+    @patch('silo.gviews_v4._get_authorized_service')
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_import_from_gsheet_helper_unique_fields_no_lvs(
+            self, mock_get_credential_obj, mock_get_authorized_service,
+            mock_get_gsheet_metadata, mock_fetch_data_gsheet,
+            mock_get_or_create_read):
+        data = [
+            ['Name', 'Last.Name', 'E-mail'],
+            ['John', 'Doe', 'john@example.org'],
+            ['Bob', 'Smith', 'bob@example.org'],
+        ]
+        expected_result = [
+            {'silo_id': self.silo.id},
+            {'msg': 'Operation successful', 'level': messages.SUCCESS}
+        ]
+
+        mock_get_credential_obj.return_value = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        mock_get_gsheet_metadata.return_value = (Mock(), None)
+        mock_fetch_data_gsheet.return_value = (data, None)
+        mock_get_or_create_read.return_value = self.read
+
+        result = gviews_v4.import_from_gsheet_helper(
+            self.tola_user.user, self.silo.id, self.silo.name, 1234)
+        self.assertEqual(result, expected_result)
+
+    @patch('silo.gviews_v4._get_or_create_read')
+    @patch('silo.gviews_v4._fetch_data_gsheet')
+    @patch('silo.gviews_v4._get_gsheet_metadata')
+    @patch('silo.gviews_v4._get_authorized_service')
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_import_from_gsheet_helper_skipped_rows(
+            self, mock_get_credential_obj, mock_get_authorized_service,
+            mock_get_gsheet_metadata, mock_fetch_data_gsheet,
+            mock_get_or_create_read):
+        lvs = LabelValueStore()
+        lvs.silo_id = self.silo.id
+        lvs.save()
+        data = [{
+            'First.Name': 'John',
+            'Last.Name': 'Doe',
+            'E-mail': 'john@example.org',
+        }, {
+            'First.Name': 'Bob',
+            'Last.Name': 'Smith',
+            'E-mail': 'bob@example.org',
+        }]
+        save_data_to_silo(self.silo, data, self.read)
+
+        # create multiple lvs
+        lvs = LabelValueStore()
+        lvs.silo_id = self.silo.id
+        lvs.save()
+        save_data_to_silo(self.silo, data, self.read)
+
+        factories.UniqueFields(name='E-mail', silo=self.silo)
+        data = [
+            ['First.Name', 'Last.Name', 'E-mail'],
+            ['John', 'Lennon', 'john@example.org'],
+        ]
+        expected_result = [
+            {'silo_id': self.silo.id},
+            {'msg': 'Skipped updating/adding records where '
+                    'E-mail=john@example.org,silo_id=1 because there are '
+                    'already multiple records.', 'level': messages.WARNING},
+            {'msg': 'Operation successful', 'level': messages.SUCCESS}]
+
+        mock_get_credential_obj.return_value = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        mock_get_gsheet_metadata.return_value = (Mock(), None)
+        mock_fetch_data_gsheet.return_value = (data, None)
+        mock_get_or_create_read.return_value = self.read
+
+        result = gviews_v4.import_from_gsheet_helper(
+            self.tola_user.user, self.silo.id, self.silo.name, 1234,
+            partialcomplete=True)
+        self.assertEqual(result, ([], expected_result))
+
+
+class GetGSheetMetaDataTest(TestCase):
+    def setUp(self):
+        self.org = factories.Organization()
+        self.tola_user = factories.TolaUser(organization=self.org)
+        self.read = factories.Read(read_name='Test Read')
+
+    @patch('silo.gviews_v4._get_authorized_service')
+    def test_get_gsheet_metadata_success(self, mock_get_authorized_service):
+        mock_service_execute = Mock()
+        mock_credential_obj = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        gviews_v4._get_authorized_service().spreadsheets().\
+            get().execute.return_value = mock_service_execute
+
+        spreadsheet, error = gviews_v4._get_gsheet_metadata(
+            mock_credential_obj, 1234, self.tola_user.user)
+
+        self.assertIsNone(error)
+        self.assertEqual(spreadsheet, mock_service_execute)
+
+    @patch('silo.gviews_v4._get_credential_object')
+    def test_get_gsheet_metadata_refresh_error(self, mock_get_credential_obj):
+        refresh_exception = HttpAccessTokenRefreshError()
+        mock_credential_obj = Mock(OAuth2Credentials)
+        mock_new_credential_obj = Mock(OAuth2Credentials)
+
+        mock_service_execute = Mock(side_effect=refresh_exception)
+        mock_get_credential_obj.return_value = mock_new_credential_obj
+        gviews_v4._get_authorized_service = Mock()
+        gviews_v4._get_authorized_service().spreadsheets = mock_service_execute
+
+        spreadsheet, error = gviews_v4._get_gsheet_metadata(
+            mock_credential_obj, 1234, self.tola_user.user)
+
+        expected_error = {
+            'credential': [mock_new_credential_obj]
+        }
+
+        self.assertIsNotNone(error)
+        self.assertIsNone(spreadsheet)
+        self.assertEqual(error, expected_error)
+
+    def test_get_gsheet_metadata_exception(self):
+        exception = Exception()
+        exception.__setattr__(
+            'content', '{"error": {"status": "ERROR", "message": "Msg Test"}}')
+
+        mock_credential_obj = Mock(OAuth2Credentials)
+        mock_service_execute = Mock(side_effect=exception)
+        gviews_v4._get_authorized_service = Mock()
+        gviews_v4._get_authorized_service().spreadsheets = mock_service_execute
+
+        spreadsheet, error = gviews_v4._get_gsheet_metadata(
+            mock_credential_obj, 1234, self.tola_user.user)
+
+        expected_error = {
+            'msg': 'ERROR: Msg Test',
+            'level': messages.ERROR
+        }
+
+        self.assertIsNotNone(error)
+        self.assertIsNone(spreadsheet)
+        self.assertEqual(error, expected_error)
+
+
+class FetchDataGSheetTest(TestCase):
+    def setUp(self):
+        logging.disable(logging.ERROR)
+        self.org = factories.Organization()
+        self.tola_user = factories.TolaUser(organization=self.org)
+        self.read = factories.Read(read_name='Test Read')
+        self.silo = factories.Silo(reads=[self.read])
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    @patch('silo.gviews_v4._get_authorized_service')
+    def test_fetch_data_gsheet_success(self, mock_get_authorized_service):
+        data = {
+            'name': 'John',
+            'age': 40
+        }
+        mock_credential_obj = Mock(OAuth2Credentials)
+        mock_get_authorized_service.return_value = Mock()
+        gviews_v4._get_authorized_service().spreadsheets().values().get().\
+            execute().get.return_value = data
+
+        values, error = gviews_v4._fetch_data_gsheet(
+            mock_credential_obj, 1234, 'Syria Security Incidences')
+
+        self.assertIsNone(error)
+        self.assertEqual(values, data)
+
+    def test_fetch_data_gsheet_exception(self):
+        exception = Exception('Deu ruim')
+
+        mock_credential_obj = Mock(OAuth2Credentials)
+        mock_service_execute = Mock(side_effect=exception)
+        gviews_v4._get_authorized_service = Mock()
+        gviews_v4._get_authorized_service().spreadsheets = mock_service_execute
+
+        values, error = gviews_v4._fetch_data_gsheet(
+            mock_credential_obj, 1234, 'Syria Security Incidences')
+
+        expected_error = {
+            'level': messages.ERROR,
+            'msg': 'Something went wrong 22: Deu ruim',
+            'redirect': None
+        }
+
+        self.assertIsNotNone(error)
+        self.assertIsNone(values)
+        self.assertEqual(error, expected_error)
+
+
+class ConvertGSheetDataTest(TestCase):
+    def test_convert_gsheet_data_success(self):
+        headers = ['Name', 'Age']
+        values = [
+            ['Paul', '75'],
+            ['John', '40'],
+        ]
+
+        expected_data = [{'Age': '75', 'Name': 'Paul'},
+                         {'Age': '40', 'Name': 'John'}]
+
+        data = gviews_v4._convert_gsheet_data(headers, values)
+        self.assertEqual(expected_data, data)
+
+    def test_convert_gsheet_data_longer_values_than_header(self):
+        headers = ['Name', 'Age']
+        values = [
+            ['Paul', '75', 'McCartney'],
+            ['John', '40', 'Lennon'],
+        ]
+
+        expected_data = [{'Age': '75', 'Name': 'Paul'},
+                         {'Age': '40', 'Name': 'John'}]
+
+        data = gviews_v4._convert_gsheet_data(headers, values)
+        self.assertEqual(expected_data, data)
+
+    def test_convert_gsheet_data_longer_header_than_values(self):
+        headers = ['Name', 'Age', 'Surname']
+        values = [
+            ['Paul', '75'],
+            ['John', '40'],
+        ]
+
+        expected_data = [{'Age': '75', 'Name': 'Paul'},
+                         {'Age': '40', 'Name': 'John'}]
+
+        data = gviews_v4._convert_gsheet_data(headers, values)
+        self.assertEqual(expected_data, data)
+
+    def test_convert_gsheet_data_empty_header(self):
+        values = [
+            ['Paul', '75'],
+            ['John', '40'],
+        ]
+
+        data = gviews_v4._convert_gsheet_data(list(), values)
+        self.assertEqual(list(), data)
+
+    def test_convert_gsheet_data_empty_values(self):
+        headers = ['Name', 'Age']
+
+        data = gviews_v4._convert_gsheet_data(headers, list())
+        self.assertEqual(list(), data)
+
+    def test_convert_gsheet_data_header_error(self):
+        headers = [['Name', 'Age']]
+        values = [
+            ['Paul', '75'],
+            ['John', '40'],
+        ]
+
+        with self.assertRaises(TypeError):
+            gviews_v4._convert_gsheet_data(headers, values)
+
+    def test_convert_gsheet_data_values_error(self):
+        headers = ['Name', 'Age']
+        values = ['Paul', 75, 'John', 40]
+
+        with self.assertRaises(TypeError):
+            gviews_v4._convert_gsheet_data(headers, values)

--- a/silo/tests/test_siloview.py
+++ b/silo/tests/test_siloview.py
@@ -7,7 +7,7 @@ import factories
 import json
 from silo.api import SiloViewSet
 from silo.models import LabelValueStore
-from tola.util import saveDataToSilo
+from tola.util import save_data_to_silo
 
 
 class SiloListViewTest(TestCase):
@@ -89,7 +89,7 @@ class SiloDataViewTest(TestCase):
                                 'sample_data/moviesbyearnings2013.json')
         with open(filename, 'r') as f:
             data = json.load(f)
-            saveDataToSilo(silo, data, read)
+            save_data_to_silo(silo, data, read)
 
     def setUp(self):
         self.factory = APIRequestFactory()

--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -210,7 +210,7 @@ class ExportViewsTest(TestCase, MongoTestCase):
             'color': 'red',
             'type': 'primary'
         }]
-        util.saveDataToSilo(silo, data, read)
+        util.save_data_to_silo(silo, data, read)
 
         # Export to CSV
         request = self.factory.get('')
@@ -380,7 +380,7 @@ class SiloViewsTest(TestCase, MongoTestCase):
             'color': 'red',
             'type': 'primary'
         }]
-        util.saveDataToSilo(silo, data, read)
+        util.save_data_to_silo(silo, data, read)
 
         # Check if the data was inserted
         filter_fields = {}
@@ -552,7 +552,7 @@ class SaveAndImportReadViewTest(TestCase):
         self.tola_user = factories.TolaUser(organization=self.org)
         self.factory = APIRequestFactory()
 
-    @patch('silo.views.saveDataToSilo')
+    @patch('silo.views.save_data_to_silo')
     @patch('silo.views.requests')
     def test_save_and_import_read(self, mock_requests, mock_savedatasilo):
         data_res = {'detail': 'Success'}

--- a/silo/views.py
+++ b/silo/views.py
@@ -31,7 +31,7 @@ from django.views.generic import View
 
 from gviews_v4 import import_from_gsheet_helper
 from silo.custom_csv_dict_reader import CustomDictReader
-from tola.util import importJSON, saveDataToSilo, getSiloColumnNames, \
+from tola.util import importJSON, save_data_to_silo, getSiloColumnNames, \
     parseMathInstruction, calculateFormulaColumn, makeQueryForHiddenRow, \
     getNewestDataDate, addColsToSilo, deleteSiloColumns, hideSiloColumns,  \
     getCompleteSiloColumnNames, setSiloColumnType, getColToTypeDict
@@ -550,7 +550,7 @@ def saveAndImportRead(request):
         silo.reads.add(read)
 
     # import data into this silo
-    saveDataToSilo(silo, data, read, request.user)
+    save_data_to_silo(silo, data, read, request.user)
     silo_detail_url = reverse_lazy('siloDetail', args=[silo.pk])
     return HttpResponse(silo_detail_url)
 
@@ -1080,7 +1080,7 @@ def updateSiloData(request, pk):
             #put in the new records
             for x in range(0,len(data[0])):
                 for entry in data[1][x]:
-                    saveDataToSilo(silo,entry,data[0][x],request.user)
+                    save_data_to_silo(silo,entry,data[0][x],request.user)
             for read in reads:
                 if read.type.read_type == "GSheet Import":
                     greturn = import_from_gsheet_helper(request.user, silo.id, None, read.resource_id, None, True)

--- a/tola/tests/test_util.py
+++ b/tola/tests/test_util.py
@@ -2,7 +2,11 @@ from django.test import TestCase
 from bson import ObjectId
 
 import json
-from tola.util import JSONEncoder
+import logging
+import factories
+from silo.models import LabelValueStore
+from silo.custom_csv_dict_reader import CustomDictReader
+from tola.util import clean_data_obj, JSONEncoder, saveDataToSilo
 
 
 class RegisterViewTest(TestCase):
@@ -27,3 +31,217 @@ class RegisterViewTest(TestCase):
                                   '"statecode": "FL", "_id": {"$oid": '
                                   '"5aaf820a58d8e7002c889905"}, "policy_id": '
                                   '353022}')
+
+
+class CleanDataObjTest(TestCase):
+    """
+    Tests the clean_data_obj function.
+    - The returned dict should match with the given data
+    - The function has to convert the data values to the right type
+    """
+
+    def test_clean_data_obj_success(self):
+        rows = [{
+            'name': 'John',
+            'age': '40',
+            'active': '1957-1980',
+            'rate': '9.7'
+        }]
+
+        expected_data = {
+            'name': 'John',
+            'age': 40,
+            'active': '1957-1980',
+            'rate': 9.7
+        }
+
+        result = clean_data_obj(rows)
+        self.assertEqual(result[0], expected_data)
+
+    def test_clean_data_obj_javascript(self):
+        rows = [{
+            'name': 'John',
+            'age': '40',
+            'active': '<script src=/hacker/bad.js></script>',
+            'rate': '9.7'
+        }]
+
+        expected_data = {
+            'name': 'John',
+            'age': 40,
+            'active': '&lt;script src=/hacker/bad.js&gt;&lt;/script&gt;',
+            'rate': 9.7
+        }
+
+        result = clean_data_obj(rows)
+        self.assertEqual(result[0], expected_data)
+
+    def test_clean_data_obj_empty_obj(self):
+        result = clean_data_obj({})
+        self.assertEqual(result, {})
+
+    def test_clean_data_obj_list_data(self):
+        row = ['John', '40', '1957-1980', '9.7']
+        expected_data = ['John', 40, '1957-1980', 9.7]
+
+        result = clean_data_obj(row)
+        self.assertEqual(result, expected_data)
+
+
+class SaveDataToSiloTest(TestCase):
+    """
+    Tests the clean_data_obj function.
+    - The returned dict should match with the given data
+    - The function has to convert the data values to the right type
+    """
+
+    def setUp(self):
+        self.tola_user = factories.TolaUser()
+        self.read = factories.Read(read_name='Test Read')
+        self.silo = factories.Silo(owner=self.tola_user.user,
+                                   reads=[self.read])
+        logging.disable(logging.ERROR)
+
+    def tearDown(self):
+        # Have to remove the created lvs
+        lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
+        for lvs in lvss:
+            lvs.delete()
+        logging.disable(logging.NOTSET)
+
+    def test_save_data_to_silo_success(self):
+        read_file = open('silo/tests/sample_data/test.csv')
+        reader = CustomDictReader(read_file)
+        expected_response = {
+            'skipped_rows': set([]),
+            'num_rows': 4
+        }
+
+        result = saveDataToSilo(self.silo, reader, self.read)
+        self.assertEqual(result, expected_response)
+
+    def test_save_data_to_silo_already_lvs(self):
+        read_file = open('silo/tests/sample_data/test.csv')
+        reader = CustomDictReader(read_file)
+        lvs = factories.LabelValueStore()
+        lvs.silo_id = self.silo.id
+        lvs.save()
+        expected_response = {
+            'skipped_rows': set([]),
+            'num_rows': 4
+        }
+
+        result = saveDataToSilo(self.silo, reader, self.read)
+        self.assertEqual(result, expected_response)
+        self.assertEqual(self.silo.data_count, 5)
+
+    def test_save_data_to_silo_default_read(self):
+        read_file = open('silo/tests/sample_data/test.csv')
+        reader = CustomDictReader(read_file)
+        expected_response = {
+            'skipped_rows': set([]),
+            'num_rows': 4
+        }
+
+        result = saveDataToSilo(self.silo, reader)
+        lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
+        self.assertEqual(result, expected_response)
+        for lvs in lvss:
+            self.assertEqual(lvs.read_id, -1)
+
+    def test_save_data_to_silo_list_dict(self):
+        data = [{
+            'name': 'John',
+            'age': '40',
+            'active': '1957-1980',
+            'rate': '9.7'
+        }]
+        expected_response = {
+            'skipped_rows': set([]),
+            'num_rows': 1
+        }
+
+        result = saveDataToSilo(self.silo, data, self.read)
+        self.assertEqual(result, expected_response)
+
+    def test_save_data_to_silo_empty(self):
+        expected_response = {
+            'skipped_rows': set([]),
+            'num_rows': 0
+        }
+
+        result = saveDataToSilo(self.silo, list(), self.read)
+        self.assertEqual(result, expected_response)
+
+    def test_save_data_to_silo_unique_field(self):
+        read_file = open('silo/tests/sample_data/test.csv')
+        reader = CustomDictReader(read_file)
+        lvs = factories.LabelValueStore()
+        lvs.silo_id = self.silo.id
+        lvs.save()
+        expected_response = {
+            'skipped_rows': set([]),
+            'num_rows': 1
+        }
+
+        saveDataToSilo(self.silo, reader, self.read)
+        factories.UniqueFields(name='E-mail', silo=self.silo)
+        data = [{
+            'First.Name': 'John',
+            'Last.Name': 'Lennon',
+            'E-mail': 'john@example.org',
+        }]
+
+        result = saveDataToSilo(self.silo, data, self.read)
+        self.assertEqual(result, expected_response)
+        lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
+        count = 0
+        for lvs in lvss:
+            lvs_json = json.loads(lvs.to_json())
+            if lvs_json.get('First_Name') == 'John':
+                self.assertEqual(lvs_json.get('Last_Name'), 'Lennon')
+                count += 1
+
+        self.assertEqual(count, 1)
+
+    def test_save_data_to_silo_unique_field_no_lvs(self):
+        read_file = open('silo/tests/sample_data/test.csv')
+        reader = CustomDictReader(read_file)
+        expected_response = {
+            'skipped_rows': set([]),
+            'num_rows': 4
+        }
+        factories.UniqueFields(name='E-mail', silo=self.silo)
+        result = saveDataToSilo(self.silo, reader, self.read)
+        self.assertEqual(result, expected_response)
+
+    def test_save_data_to_silo_skipped_rows(self):
+        read_file = open('silo/tests/sample_data/test.csv')
+        reader = CustomDictReader(read_file)
+        lvs = factories.LabelValueStore()
+        lvs.silo_id = self.silo.id
+        lvs.save()
+        saveDataToSilo(self.silo, reader, self.read)
+
+        # create multiple lvs
+        read_file = open('silo/tests/sample_data/test.csv')
+        reader = CustomDictReader(read_file)
+        lvs = factories.LabelValueStore()
+        lvs.silo_id = self.silo.id
+        lvs.save()
+        saveDataToSilo(self.silo, reader, self.read)
+
+        factories.UniqueFields(name='E-mail', silo=self.silo)
+        skipped_rows = ['E-mail=john@example.org',
+                        'silo_id={}'.format(self.silo.id)]
+        expected_response = {
+            'skipped_rows': set(skipped_rows),
+            'num_rows': 0}
+        data = [{
+            'First.Name': 'John',
+            'Last.Name': 'Lennon',
+            'E-mail': 'john@example.org',
+        }]
+
+        result = saveDataToSilo(self.silo, data, self.read)
+        self.assertEqual(result, expected_response)

--- a/tola/tests/test_util.py
+++ b/tola/tests/test_util.py
@@ -6,7 +6,7 @@ import logging
 import factories
 from silo.models import LabelValueStore
 from silo.custom_csv_dict_reader import CustomDictReader
-from tola.util import clean_data_obj, JSONEncoder, saveDataToSilo
+from tola.util import clean_data_obj, JSONEncoder, save_data_to_silo
 
 
 class RegisterViewTest(TestCase):
@@ -88,7 +88,7 @@ class CleanDataObjTest(TestCase):
         self.assertEqual(result, expected_data)
 
 
-class SaveDataToSiloTest(TestCase):
+class save_data_to_siloTest(TestCase):
     """
     Tests the clean_data_obj function.
     - The returned dict should match with the given data
@@ -117,7 +117,7 @@ class SaveDataToSiloTest(TestCase):
             'num_rows': 4
         }
 
-        result = saveDataToSilo(self.silo, reader, self.read)
+        result = save_data_to_silo(self.silo, reader, self.read)
         self.assertEqual(result, expected_response)
 
     def test_save_data_to_silo_already_lvs(self):
@@ -131,7 +131,7 @@ class SaveDataToSiloTest(TestCase):
             'num_rows': 4
         }
 
-        result = saveDataToSilo(self.silo, reader, self.read)
+        result = save_data_to_silo(self.silo, reader, self.read)
         self.assertEqual(result, expected_response)
         self.assertEqual(self.silo.data_count, 5)
 
@@ -143,7 +143,7 @@ class SaveDataToSiloTest(TestCase):
             'num_rows': 4
         }
 
-        result = saveDataToSilo(self.silo, reader)
+        result = save_data_to_silo(self.silo, reader)
         lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
         self.assertEqual(result, expected_response)
         for lvs in lvss:
@@ -161,7 +161,7 @@ class SaveDataToSiloTest(TestCase):
             'num_rows': 1
         }
 
-        result = saveDataToSilo(self.silo, data, self.read)
+        result = save_data_to_silo(self.silo, data, self.read)
         self.assertEqual(result, expected_response)
 
     def test_save_data_to_silo_empty(self):
@@ -170,7 +170,7 @@ class SaveDataToSiloTest(TestCase):
             'num_rows': 0
         }
 
-        result = saveDataToSilo(self.silo, list(), self.read)
+        result = save_data_to_silo(self.silo, list(), self.read)
         self.assertEqual(result, expected_response)
 
     def test_save_data_to_silo_unique_field(self):
@@ -184,7 +184,7 @@ class SaveDataToSiloTest(TestCase):
             'num_rows': 1
         }
 
-        saveDataToSilo(self.silo, reader, self.read)
+        save_data_to_silo(self.silo, reader, self.read)
         factories.UniqueFields(name='E-mail', silo=self.silo)
         data = [{
             'First.Name': 'John',
@@ -192,7 +192,7 @@ class SaveDataToSiloTest(TestCase):
             'E-mail': 'john@example.org',
         }]
 
-        result = saveDataToSilo(self.silo, data, self.read)
+        result = save_data_to_silo(self.silo, data, self.read)
         self.assertEqual(result, expected_response)
         lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
         count = 0
@@ -212,7 +212,7 @@ class SaveDataToSiloTest(TestCase):
             'num_rows': 4
         }
         factories.UniqueFields(name='E-mail', silo=self.silo)
-        result = saveDataToSilo(self.silo, reader, self.read)
+        result = save_data_to_silo(self.silo, reader, self.read)
         self.assertEqual(result, expected_response)
 
     def test_save_data_to_silo_skipped_rows(self):
@@ -221,7 +221,7 @@ class SaveDataToSiloTest(TestCase):
         lvs = factories.LabelValueStore()
         lvs.silo_id = self.silo.id
         lvs.save()
-        saveDataToSilo(self.silo, reader, self.read)
+        save_data_to_silo(self.silo, reader, self.read)
 
         # create multiple lvs
         read_file = open('silo/tests/sample_data/test.csv')
@@ -229,7 +229,7 @@ class SaveDataToSiloTest(TestCase):
         lvs = factories.LabelValueStore()
         lvs.silo_id = self.silo.id
         lvs.save()
-        saveDataToSilo(self.silo, reader, self.read)
+        save_data_to_silo(self.silo, reader, self.read)
 
         factories.UniqueFields(name='E-mail', silo=self.silo)
         skipped_rows = ['E-mail=john@example.org',
@@ -243,5 +243,5 @@ class SaveDataToSiloTest(TestCase):
             'E-mail': 'john@example.org',
         }]
 
-        result = saveDataToSilo(self.silo, data, self.read)
+        result = save_data_to_silo(self.silo, data, self.read)
         self.assertEqual(result, expected_response)

--- a/tola/util.py
+++ b/tola/util.py
@@ -63,7 +63,7 @@ def parseMathInstruction(operation):
         raise TypeError(operation)
 
 
-def saveDataToSilo(silo, data, read=-1, user=None):
+def save_data_to_silo(silo, data, read=-1, user=None):
     """
     This saves data to the silo
 
@@ -223,7 +223,7 @@ def importJSON(read_obj, user, remote_user=None, password=None, silo_id=None, si
         if return_data:
             return data
 
-        saveDataToSilo(silo, data, read_obj)
+        save_data_to_silo(silo, data, read_obj)
         return messages.SUCCESS, "Data imported successfully.", str(silo_id)
     except Exception as e:
         if return_data:
@@ -433,7 +433,7 @@ def saveOnaDataToSilo(silo, data, read, user):
     form_metadata = json.loads(response.content)
 
     # if this is true than the data isn't a form so proceed to
-    # saveDataToSilo normally
+    # save_data_to_silo normally
     if "detail" in form_metadata:
         return
     else:


### PR DESCRIPTION
## Purpose
When a user tries to import data with numbers, the data is saved as strings all the time.

## Approach
- I had to convert the imported data before saving it into the MongoDB.
- Escape the string before saving the data into the database

### Furter Info 
Related ticket: #454 
