### PR TITLE
fix #466 - redirect unauthorized users to activity login page

### DIFF
--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -110,52 +110,19 @@ class IndexViewTest(TestCase):
         response = views.IndexView.as_view()(request)
         self.assertEqual(response.status_code, 302)
     """
-
     @override_settings(TOLA_ACTIVITY_API_URL='https://api.toladata.io')
     @override_settings(ACTIVITY_URL='https://toladata.io')
     def test_index_get_unauthenticated(self):
-        request = self.factory.get('', follow=True)
-        request.user = AnonymousUser()
-        request.META['HTTP_REFERER'] = 'https://api.toladata.io'
-        response = views.IndexView.as_view()(request)
-        self.assertEqual(response.status_code, 302)
-        self.assertIn('login/tola', response.url)
-
-    @override_settings(TOLA_ACTIVITY_API_URL='https://api.toladata.io')
-    @override_settings(ACTIVITY_URL='https://toladata.io')
-    def test_index_get_from_index_page(self):
-        request = self.factory.get('', follow=True)
-        request.user = AnonymousUser()
-        request.META['HTTP_REFERER'] = 'https://api.toladata.io'
-        response = views.IndexView.as_view()(request)
-        self.assertEqual(response.status_code, 302)
-        self.assertIn('login/tola', response.url)
-
-    @override_settings(TOLA_ACTIVITY_API_URL='https://api.toladata.io')
-    @override_settings(ACTIVITY_URL='https://toladata.io')
-    def test_index_get_from_app(self):
-        request = self.factory.get('', follow=True)
-        request.user = AnonymousUser()
-        request.META['HTTP_REFERER'] = 'https://toladata.io'
-        response = views.IndexView.as_view()(request)
+        response = self.client.get('/')
         self.assertEqual(response.status_code, 302)
         self.assertIn('login/tola', response.url)
 
     @override_settings(TOLA_ACTIVITY_API_URL=None)
     @override_settings(ACTIVITY_URL='https://toladata.io')
     def test_index_get_unauthenticated_no_activity_api_url(self):
-        request = self.factory.get('')
-        request.user = AnonymousUser()
-        with self.assertRaises(ImproperlyConfigured):
-            views.IndexView.as_view()(request)
-
-    @override_settings(TOLA_ACTIVITY_API_URL='https://api.toladata.io')
-    @override_settings(ACTIVITY_URL=None)
-    def test_index_get_unauthenticated_no_activity_url(self):
-        request = self.factory.get('')
-        request.user = AnonymousUser()
-        with self.assertRaises(ImproperlyConfigured):
-            views.IndexView.as_view()(request)
+        response = self.client.get('')
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('login/tola', response.url)
 
 
 class ExportViewsTest(TestCase, MongoTestCase):

--- a/tola/settings/base.py
+++ b/tola/settings/base.py
@@ -257,6 +257,7 @@ SOCIAL_AUTH_PIPELINE = (
 ########## Login redirect ###########
 LOGIN_REDIRECT_URL = '/'
 SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/'
+LOGIN_URL = '/login/tola'
 
 ########## LOGGING CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#logging

--- a/tola/tests/test_views.py
+++ b/tola/tests/test_views.py
@@ -1,11 +1,16 @@
+
 from django.test import Client, override_settings, TestCase, RequestFactory
 from django.conf import settings
 from django.contrib import auth
+from django.urls import reverse
 
 import factories
+import json
+import uuid
+from rest_framework.test import APIRequestFactory
+from silo.api import CustomFormViewSet
 from tola.views import register
 from urlparse import urljoin
-
 
 class RegisterViewTest(TestCase):
     def setUp(self):
@@ -151,3 +156,13 @@ class LogoutViewTest(TestCase):
         self.assertEqual(self.user.is_authenticated(), False)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, settings.ACTIVITY_URL)
+
+
+class LoginTest(TestCase):
+    @override_settings(TABLES_URL='https://tolaactivity.com')
+    def test_unauthorized_user_login_redirect(self):
+        silo = factories.Silo()
+        url= reverse('siloDetail', args=[silo.pk])
+        response = self.client.get(url)
+        self.assertIn(settings.LOGIN_URL, response.url)
+        self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
## Purpose
Preventing unauthorized users to redirect TolaTables login page when they try to access Track and redirect them to Activity login page.
## Approach
Login url added to settings.

_Related ticket: #466 
