### PR TITLE
Fix the deleting document issue in SiloDataViewTest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 pipeline:
   mongo-setup:
-    image: mongo:3.0
+    image: mongo:3.4.10
     commands:
       - sleep 15
       - 'mongo --host mongo --eval "db.getSiblingDB(''test'').createUser({user:''test'', pwd:''test'', roles:[{role:''dbOwner'', db:''test''}]});"'

--- a/silo/tests/test_siloview.py
+++ b/silo/tests/test_siloview.py
@@ -99,13 +99,11 @@ class SiloDataViewTest(TestCase):
                                    owner=self.tola_user.user)
         self.silo = factories.Silo(owner=self.tola_user.user,
                                    reads=[self.read])
-        self._import_json(self.silo, self.read)
-
-    def tearDown(self):
         # Have to remove the created lvs
         lvss = LabelValueStore.objects.filter(silo_id=self.silo.id)
         for lvs in lvss:
             lvs.delete()
+        self._import_json(self.silo, self.read)
 
     def test_data_silo(self):
         request = self.factory.get('/api/silo/{}/data'.format(self.silo.id))


### PR DESCRIPTION
## Purpose
There's a weird error in the `test_data_silo` test and it's related to MongoDB. Currently, we don't know exactly what the problem is. The deletion of documents isn't working properly in the `tearDown` but if we add it to the `setUp` it works as expected.

### Furter Info
@leonholub and @bogdangi we should keep tracking this issue and check how to definitely solve it.

