### PR TITLE
fix 477 - add id column to track tables

### DIFF
--- a/datasources/commcare/views.py
+++ b/datasources/commcare/views.py
@@ -103,7 +103,7 @@ def getCommCareAuth(request):
                     messages.add_message(request,ret[0],ret[1])
                     #need to impliment if import faluire
                     cols = ret[2]
-                    return HttpResponseRedirect(reverse_lazy("siloDetail", kwargs={'silo_id' : silo.id}))
+                    return HttpResponseRedirect(reverse_lazy("silo_detail", kwargs={'silo_id' : silo.id}))
 
                 else:
                     messages.error(request, "A %s error has occured: %s " % (response.status_code, response.text))
@@ -185,7 +185,7 @@ def getCommCareFormPass(request):
                 #need to impliment if import faluire
                 messages.add_message(request,ret[0],ret[1])
                 cols = ret[2]
-                return HttpResponseRedirect(reverse_lazy("siloDetail", kwargs={'silo_id' : silo.id}))
+                return HttpResponseRedirect(reverse_lazy("silo_detail", kwargs={'silo_id' : silo.id}))
 
             else:
                 messages.error(request, "A %s error has occured: %s " % (response.status_code, response.text))

--- a/silo/google_views.py
+++ b/silo/google_views.py
@@ -291,7 +291,7 @@ def import_gsheet(request, id):
     try:
         silo = Silo.objects.get(id=id)
         if silo.unique_fields.exists() == False:
-            messages.error(request, "A unique column must be specfied when importing to an existing table. <a href='%s'>Specify Unique Column</a>" % reverse_lazy('siloDetail', kwargs={"id": silo.id}))
+            messages.error(request, "A unique column must be specfied when importing to an existing table. <a href='%s'>Specify Unique Column</a>" % reverse_lazy('silo_detail', kwargs={"id": silo.id}))
             return HttpResponseRedirect(request.META['HTTP_REFERER'])
     except Silo.DoesNotExist:
         silo = Silo(name=file_name, owner=request.user, public=False, description="Google Sheet Import")
@@ -312,7 +312,7 @@ def import_gsheet(request, id):
 
     #print("about to export to gsheet: %s" % gsheet_endpoint.resource_id)
     if import_from_google_spreadsheet(credential_json, silo, gsheet_endpoint.resource_id) == True:
-        link = "Your imported data is available at here. <a href='%s'>See the table</a>" % reverse_lazy('siloDetail', kwargs={"id": silo.id})
+        link = "Your imported data is available at here. <a href='%s'>See the table</a>" % reverse_lazy('silo_detail', kwargs={"id": silo.id})
         messages.success(request, link)
     else:
         messages.error(request, 'Something went wrong.')

--- a/silo/gviews_v4.py
+++ b/silo/gviews_v4.py
@@ -311,7 +311,7 @@ def import_from_gsheet(request, id):
             return HttpResponseRedirect(msg.get("redirect"))
         messages.add_message(request, msg.get("level", "warning"), msg.get("msg", None))
 
-    return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': str(id)},))
+    return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': str(id)},))
 
 
 def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):

--- a/silo/tests/test.py
+++ b/silo/tests/test.py
@@ -15,7 +15,7 @@ from silo.forms import get_read_form
 from silo.models import (DeletedSilos, LabelValueStore, ReadType, Read, Silo,
                          CeleryTask)
 from silo.views import (addColumnFilter, editColumnOrder, newFormulaColumn,
-                        showRead, editSilo, uploadFile, siloDetail)
+                        showRead, editSilo, uploadFile, silo_detail)
 from tola.util import (addColsToSilo, hideSiloColumns, getColToTypeDict,
                        getSiloColumnNames, cleanKey)
 
@@ -173,7 +173,7 @@ class SiloDetailTest(TestCase):
         request = self.factory.get(self.silo_detail_url)
         request.user = self.user
 
-        response = siloDetail(request, silo.pk)
+        response = silo_detail(request, silo.pk)
         self.assertContains(
             response,
             '<a href="/show_read/{}" target="_blank">{}</a>'.format(
@@ -201,7 +201,7 @@ class SiloDetailTest(TestCase):
         request = self.factory.get(self.silo_detail_url)
         request.user = self.user
 
-        response = siloDetail(request, silo.pk)
+        response = silo_detail(request, silo.pk)
         self.assertContains(
             response,
             '<a href="/show_read/{}" target="_blank">{}</a>'.format(
@@ -230,7 +230,7 @@ class SiloDetailTest(TestCase):
         request = self.factory.get(self.silo_detail_url)
         request.user = self.user
 
-        response = siloDetail(request, silo.pk)
+        response = silo_detail(request, silo.pk)
         self.assertContains(
             response,
             '<a href="/show_read/{}" target="_blank">{}</a>'.format(
@@ -353,7 +353,7 @@ class SiloTest(TestCase):
         request = self.factory.get(self.silo_detail_url)
         request.user = self.tola_user.user
 
-        response = siloDetail(request, silo.pk)
+        response = silo_detail(request, silo.pk)
         self.assertEqual(response.status_code, 200)
 
         # now delete that silo data cause this uses the custom database

--- a/silo/views.py
+++ b/silo/views.py
@@ -536,7 +536,7 @@ def saveAndImportRead(request):
 
     # import data into this silo
     save_data_to_silo(silo, data, read, request.user)
-    silo_detail_url = reverse_lazy('siloDetail', args=[silo.pk])
+    silo_detail_url = reverse_lazy('silo_detail', args=[silo.pk])
     return HttpResponse(silo_detail_url)
 
 
@@ -977,30 +977,36 @@ def updateEntireColumn(request):
             )
         messages.success(request, "Successfully, changed the %s column value to %s" % (colname, new_val))
 
-    return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': silo_id}))
+    return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': silo_id}))
 
 
 @login_required
-def siloDetail(request, silo_id):
+def silo_detail(request, silo_id):
     """
     Silo Detail
     """
 
     silo = Silo.objects.get(pk=silo_id)
     cols = []
-    # col_types = getColToTypeDict(silo)
-    data = []
     query = makeQueryForHiddenRow(json.loads(silo.rows_to_hide))
 
     """
-    Note:    There is a chance a service gets stuck in "tasks_running" if a service worker terminates unexpectedly and the task id
+    Note:    There is a chance a service gets stuck in "tasks_running" if a
+    service worker terminates unexpectedly and the task id
     could not be removed from the task.
     """
 
-    tasks_running = Read.objects.filter(silos=silo.id, tasks__task_status__in=[CeleryTask.TASK_CREATED, CeleryTask.TASK_IN_PROGRESS]).count()
-    tasks_failed = Read.objects.filter(silos=silo.id, tasks__task_status=CeleryTask.TASK_FAILED).count()
+    tasks_running = Read.objects.filter(
+        silos=silo.id,
+        tasks__task_status__in=[CeleryTask.TASK_CREATED,
+                                CeleryTask.TASK_IN_PROGRESS]).count()
 
-    silo_read_ids = Read.objects.filter(silos=silo.id).values_list('id', flat=True)
+    tasks_failed = Read.objects.filter(
+        silos=silo.id,
+        tasks__task_status=CeleryTask.TASK_FAILED).count()
+
+    silo_read_ids = Read.objects.filter(silos=silo.id).values_list('id',
+                                                                   flat=True)
 
     celery_tasks = CeleryTask.objects.filter(
         object_id__in=silo_read_ids,
@@ -1012,12 +1018,14 @@ def siloDetail(request, silo_id):
         celery_tasks
     )
 
-    if silo.owner == request.user or silo.public == True or request.user in silo.shared.all():
+    if silo.owner == request.user or silo.public \
+            or request.user in silo.shared.all():
         cols.append('_id')
         cols.append('id')
         cols.extend(getSiloColumnNames(silo_id))
     else:
-        messages.warning(request,"You do not have permission to view this table.")
+        messages.warning(request,
+                         "You do not have permission to view this table.")
     return render(
         request,
         "display/silo.html",
@@ -1116,7 +1124,7 @@ def updateSiloData(request, pk):
             #delete legacy objects
             lvss = LabelValueStore.objects(silo_id=silo.pk,__raw__={ "$or" : [{"read_id" : {"$not" : { "$exists" : "true" }}}, {"read_id" : {"$in" : [-1,""]} } ]})
 
-    return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': pk},))
+    return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': pk},))
 
 
 #return tuple: (list of list of dictionaries[[{}]] data, 0=falure 1=success 2=N/A, messages)
@@ -1300,7 +1308,7 @@ def edit_columns(request, id):
                 deleteSiloColumns(silo, to_delete)
             messages.info(request, 'Updates Saved', fail_silently=False)
             return HttpResponseRedirect(reverse_lazy(
-                'siloDetail', kwargs={'silo_id': silo.id}))
+                'silo_detail', kwargs={'silo_id': silo.id}))
         else:
             messages.error(request,
                            'ERROR: There was a problem with your request',
@@ -1411,7 +1419,7 @@ def do_merge(request):
                                       merge_type=merge_type)
     mapping.save()
     return HttpResponseRedirect(
-        reverse_lazy('siloDetail', kwargs={'silo_id': merge_table_id}))
+        reverse_lazy('silo_detail', kwargs={'silo_id': merge_table_id}))
 
 
 # EDIT A SINGLE VALUE STORE
@@ -1571,7 +1579,7 @@ def anonymizeTable(request, id):
     else:
         messages.info(request, "No PIIF columns were found.")
 
-    return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': id}))
+    return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': id}))
 
 
 @login_required
@@ -1616,7 +1624,7 @@ def removeSource(request, silo_id, read_id):
     except Read.DoesNotExist as e:
         messages.error(request,"Datasource with id=%s does not exist." % read_id)
 
-    return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': silo_id},))
+    return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': silo_id},))
 
 
 @login_required
@@ -1647,7 +1655,7 @@ def newFormulaColumn(request, pk):
         addColsToSilo(silo,[column_name], {column_name : 'float'})
         silo.save()
 
-        return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': pk},))
+        return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': pk},))
 
     silo = Silo.objects.get(pk=pk)
     cols = getSiloColumnNames(pk)
@@ -1676,7 +1684,7 @@ def editColumnOrder(request, pk):
             return HttpResponseRedirect(reverse_lazy('listSilos'))
 
 
-        return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': pk},))
+        return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': pk},))
 
     silo = Silo.objects.get(pk=pk)
     cols = getSiloColumnNames(pk)
@@ -1694,7 +1702,7 @@ def addColumnFilter(request, pk):
         silo.rows_to_hide = hide_rows
 
         silo.save()
-        return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': pk},))
+        return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': pk},))
 
 
     silo = Silo.objects.get(pk=pk)
@@ -1753,7 +1761,7 @@ def setColumnType(request, pk):
     #should only deal with post request since this will operate with a modal
     if request.method != 'POST':
         messages.error(request, '%s request is invalid' % request.method)
-        return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': pk}))
+        return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': pk}))
 
     silo = Silo.objects.get(pk=pk)
     column = request.POST.get('column_for_type')
@@ -1762,4 +1770,4 @@ def setColumnType(request, pk):
     msg = setSiloColumnType(int(pk), column, col_type)
     messages.add_message(request, msg[0], msg[1])
 
-    return HttpResponseRedirect(reverse_lazy('siloDetail', kwargs={'silo_id': pk},))
+    return HttpResponseRedirect(reverse_lazy('silo_detail', kwargs={'silo_id': pk},))

--- a/silo/views.py
+++ b/silo/views.py
@@ -1014,6 +1014,7 @@ def siloDetail(request, silo_id):
 
     if silo.owner == request.user or silo.public == True or request.user in silo.shared.all():
         cols.append('_id')
+        cols.append('id')
         cols.extend(getSiloColumnNames(silo_id))
     else:
         messages.warning(request,"You do not have permission to view this table.")

--- a/templates/display/silo_detail.html
+++ b/templates/display/silo_detail.html
@@ -9,8 +9,8 @@
 {% block content %}
     {% if silo.merged_silo_mappings %}
         <center>
-            Merged from <a href="{% url 'siloDetail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a>
-            and <a href="{% url 'siloDetail' silo.merged_silo_mappings.to_silo.pk %}">{{ silo.merged_silo_mappings.to_silo}}</a>
+            Merged from <a href="{% url 'silo_detail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a>
+            and <a href="{% url 'silo_detail' silo.merged_silo_mappings.to_silo.pk %}">{{ silo.merged_silo_mappings.to_silo}}</a>
         </center>
     {% endif %}
 
@@ -162,7 +162,7 @@
     $(document).ready(function() {
         //$('#table_data').on('click', 'th', function(e) {
             //e.preventDefault();
-            //var url = `{% url 'siloDetail' id %}` + $(this).children('a').attr('href');
+            //var url = `{% url 'silo_detail' id %}` + $(this).children('a').attr('href');
             //window.location = url ;
         //});
         var unique_col = $("#silo_cols_multi_select").val();

--- a/templates/display/silos.html
+++ b/templates/display/silos.html
@@ -27,7 +27,7 @@
                                     {% if silo.tags.all %}<span><small>tags: {% for tag in silo.tags.all %} <a name="tag" class="tag"> {{ tag }}</a>{% endfor %}</small></span>{%endif%}</td>
                                 <td class="tableSourcesCol">
                                     {% if silo.merged_silo_mappings %}
-                                        <span><small>Merged Tables: <a href="{% url 'siloDetail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'siloDetail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
+                                        <span><small>Merged Tables: <a href="{% url 'silo_detail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'silo_detail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
                                     {% else %}
                                         {% for r in silo.reads.all %}
                                             <a href="/show_read/{{ r.id }}" ><small> {{ r.read_name }} ({{r.type.read_type}})</small></a> <br />
@@ -90,7 +90,7 @@
                                 <td><small>{{ silo.description|default:"" }}</small></td>
                                 <td>
                                     {% if silo.merged_silo_mappings %}
-                                        <span><small>Merged Tables: <a href="{% url 'siloDetail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'siloDetail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
+                                        <span><small>Merged Tables: <a href="{% url 'silo_detail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'silo_detail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
                                     {% else %}
                                         {% for r in silo.reads.all %}
                                             <a href="/show_read/{{ r.id }}" ><small> {{ r.read_name }} ({{r.type.read_type}})</small></a> <br />
@@ -138,7 +138,7 @@
                                 <td><small>{{ silo.description|default:"" }}</small></td>
                                 <td>
                                     {% if silo.merged_silo_mappings %}
-                                        <span><small>Merged Tables: <a href="{% url 'siloDetail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'siloDetail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
+                                        <span><small>Merged Tables: <a href="{% url 'silo_detail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'silo_detail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
                                     {% else %}
                                         {% for r in silo.reads.all %}
                                             <a href="/show_read/{{ r.id }}" ><small> {{ r.read_name }} ({{r.type.read_type}})</small></a> <br />

--- a/templates2/display/silo.html
+++ b/templates2/display/silo.html
@@ -234,8 +234,13 @@
 <div class="panel panel-body" style="padding: 5px 0px 5px 0px;">
 <table id="data_table" class="table table-hover table table-striped table-bordered" style="overflow-x: scroll; display:inline-block; width:100%;" width="100%">
 <thead>
-{% for c in cols %}
-<th>{{c}}</th>
+        <th></th>
+{% for c in cols|slice:"1:" %}
+
+    {% if c != '_id' %}
+        <th>{{c}}</th>
+    {% endif %}
+
 {% endfor %}
 </thead>
 </table>
@@ -393,15 +398,23 @@
             var cols = [];
 
             $('#popuptitle').text("Detail view");
+            k = 0;
 
             // Loop through the header row and create a cols array for datatables.
             $("#data_table").find("th").each(function(i){
                 if (i == -1) {
                     // make the first col have a set width and non-sortable
                     //cols.push({"data": $(this).text(), "orderable": false , "width": "40px"});
-                } else {
+                }
+                else {
+                    if($(this).text() == '' || $(this).text() == 'id'){
+                        data = '_id';
+                    }
+                    else{
+                        data = $(this).text();
+                    }
                     cols.push({
-                        "data": $(this).text(),
+                        "data": data,
                         // Use the cell render function to return "repeats if the value is an array"
                         // This function places the data in the table on a silo
                         "render": function(data, type, row) {
@@ -426,11 +439,17 @@
                                 return cell_data + "<a href='#''>more</a>";
                             } else if(jQuery.type(data) == "object") {
                                 if (Object.keys(data) == "$oid") {
-                                  //for the update and delete information
-                                  return "<a href='/value_edit/" + data[Object.keys(data)[0]] + "'><span class='glyphicon glyphicon-edit' aria-hidden='true'></span></a> &nbsp;" +
-                                      "<a href='/value_delete/" + data[Object.keys(data)[0]] + "' class='btn-del' title='You are about to delete a record. Are you sure?'>" +
-                                      "<span style='color:red;' class='glyphicon glyphicon-trash' aria-hidden='true'></span></a>";
 
+                                    switch(k){
+                                        case 0:
+                                            k = 1;
+                                            return "<a href='/value_edit/" + data[Object.keys(data)[0]] + "'><span class='glyphicon glyphicon-edit' aria-hidden='true'></span></a> &nbsp;" +
+                                              "<a href='/value_delete/" + data[Object.keys(data)[0]] + "' class='btn-del' title='You are about to delete a record. Are you sure?'>" +
+                                              "<span style='color:red;' class='glyphicon glyphicon-trash' aria-hidden='true'></span></a>";
+                                        case 1:
+                                            k = 0;
+                                            return data[Object.keys(data)[0]];
+                                    }
                                 }
                                 else{
                                   //for any other kind of object

--- a/templates2/display/silo_detail.html
+++ b/templates2/display/silo_detail.html
@@ -9,8 +9,8 @@
 {% block content %}
     {% if silo.merged_silo_mappings %}
         <center>
-            Merged from <a href="{% url 'siloDetail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a>
-            and <a href="{% url 'siloDetail' silo.merged_silo_mappings.to_silo.pk %}">{{ silo.merged_silo_mappings.to_silo}}</a>
+            Merged from <a href="{% url 'silo_detail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a>
+            and <a href="{% url 'silo_detail' silo.merged_silo_mappings.to_silo.pk %}">{{ silo.merged_silo_mappings.to_silo}}</a>
         </center>
     {% endif %}
 
@@ -162,7 +162,7 @@
     $(document).ready(function() {
         //$('#table_data').on('click', 'th', function(e) {
             //e.preventDefault();
-            //var url = `{% url 'siloDetail' id %}` + $(this).children('a').attr('href');
+            //var url = `{% url 'silo_detail' id %}` + $(this).children('a').attr('href');
             //window.location = url ;
         //});
         var unique_col = $("#silo_cols_multi_select").val();

--- a/templates2/display/silos.html
+++ b/templates2/display/silos.html
@@ -27,7 +27,7 @@
                                     {% if silo.tags.all %}<span><small>tags: {% for tag in silo.tags.all %} <a name="tag" class="tag"> {{ tag }}</a>{% endfor %}</small></span>{%endif%}</td>
                                 <td class="tableSourcesCol">
                                     {% if silo.merged_silo_mappings %}
-                                        <span><small>Merged Tables: <a href="{% url 'siloDetail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'siloDetail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
+                                        <span><small>Merged Tables: <a href="{% url 'silo_detail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'silo_detail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
                                     {% else %}
                                         {% for r in silo.reads.all %}
                                             <a href="/show_read/{{ r.id }}" ><small> {{ r.read_name }} ({{r.type.read_type}})</small></a> <br />
@@ -98,7 +98,7 @@
                                 <td><small>{{ silo.description|default:"" }}</small></td>
                                 <td>
                                     {% if silo.merged_silo_mappings %}
-                                        <span><small>Merged Tables: <a href="{% url 'siloDetail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'siloDetail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
+                                        <span><small>Merged Tables: <a href="{% url 'silo_detail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'silo_detail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
                                     {% else %}
                                         {% for r in silo.reads.all %}
                                             <a href="/show_read/{{ r.id }}" ><small> {{ r.read_name }} ({{r.type.read_type}})</small></a> <br />
@@ -146,7 +146,7 @@
                                 <td><small>{{ silo.description|default:"" }}</small></td>
                                 <td>
                                     {% if silo.merged_silo_mappings %}
-                                        <span><small>Merged Tables: <a href="{% url 'siloDetail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'siloDetail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
+                                        <span><small>Merged Tables: <a href="{% url 'silo_detail' silo.merged_silo_mappings.from_silo.pk %}">{{silo.merged_silo_mappings.from_silo}}</a> and <a href="{% url 'silo_detail' silo.merged_silo_mappings.to_silo.pk %}">{{silo.merged_silo_mappings.to_silo}}</a></small</span>
                                     {% else %}
                                         {% for r in silo.reads.all %}
                                             <a href="/show_read/{{ r.id }}" ><small> {{ r.read_name }} ({{r.type.read_type}})</small></a> <br />

--- a/templates2/index.html
+++ b/templates2/index.html
@@ -75,7 +75,7 @@
                   {% for silo in silos_user %}
                   <tr>
                       <td>{{ silo.tag_list }}</td>
-                      <td><a href="{% url 'siloDetail' silo.id %}">{{ silo.name }}</a></td>
+                      <td><a href="{% url 'silo_detail' silo.id %}">{{ silo.name }}</a></td>
                       <td>{{ silo.description }}</td>
                       <td>{{ silo.public }}</td>
                       <td>{{ silo.created }}</td>
@@ -84,7 +84,7 @@
                   {% for silo in silos_public %}
                   <tr>
                       <td>{{ silo.tag_list }}</td>
-                      <td><a href="{% url 'siloDetail' silo.id %}">{{ silo.name }}</a></td>
+                      <td><a href="{% url 'silo_detail' silo.id %}">{{ silo.name }}</a></td>
                       <td>{{ silo.description }}</td>
                       <td>{{ silo.public }}</td>
                       <td>{{ silo.created }}</td>

--- a/tola/tests/test_views.py
+++ b/tola/tests/test_views.py
@@ -162,7 +162,7 @@ class LoginTest(TestCase):
     @override_settings(TABLES_URL='https://tolaactivity.com')
     def test_unauthorized_user_login_redirect(self):
         silo = factories.Silo()
-        url= reverse('siloDetail', args=[silo.pk])
+        url= reverse('silo_detail', args=[silo.pk])
         response = self.client.get(url)
         self.assertIn(settings.LOGIN_URL, response.url)
         self.assertEqual(response.status_code, 302)

--- a/tola/urls.py
+++ b/tola/urls.py
@@ -55,7 +55,7 @@ urlpatterns =[
     url(r'^toggle_silo_publicity/$', views.toggle_silo_publicity, name='toggle_silo_publicity'),
 
     url(r'^silos', views.listSilos, name='listSilos'),
-    url(r'^silo_detail/(?P<silo_id>\w+)/$', views.siloDetail, name='siloDetail'),
+    url(r'^silo_detail/(?P<silo_id>\w+)/$', views.silo_detail, name='silo_detail'),
     url(r'^silo_edit/(?P<id>\w+)/$', views.editSilo, name='editSilo'),
     url(r'^silo_delete/(?P<id>\w+)/$', views.deleteSilo, name='deleteSilo'),
     url(r'^add_unique_fields', views.addUniqueFiledsToSilo, name='add_unique_fields_to_silo'),


### PR DESCRIPTION
## Purpose
Add id column to track table for each row in order to make identification of data easier.

## Approach
Each row have already unique mongo id field. I show id field on the table.

_Related ticket: #477 
