### PR TITLE
Fix #487 - Add permissions to silo edit page.

### DIFF
--- a/silo/tests/test.py
+++ b/silo/tests/test.py
@@ -15,7 +15,7 @@ from silo.forms import get_read_form
 from silo.models import (DeletedSilos, LabelValueStore, ReadType, Read, Silo,
                          CeleryTask)
 from silo.views import (addColumnFilter, editColumnOrder, newFormulaColumn,
-                        showRead, editSilo, uploadFile, silo_detail)
+                        showRead, edit_silo, uploadFile, silo_detail)
 from tola.util import (addColsToSilo, hideSiloColumns, getColToTypeDict,
                        getSiloColumnNames, cleanKey)
 
@@ -310,7 +310,7 @@ class SiloTest(TestCase):
         # Fetch the silo that just got created above
         request = self.factory.get(self.silo_edit_url)
         request.user = self.tola_user.user
-        response = editSilo(request, silo.pk)
+        response = edit_silo(request, silo.pk)
         self.assertEqual(response.status_code, 200)
 
         # update the silo that just got created above
@@ -322,7 +322,7 @@ class SiloTest(TestCase):
         request = self.factory.post(self.silo_edit_url, data = params)
         request.user = self.tola_user.user
         request._dont_enforce_csrf_checks = True
-        response = editSilo(request, silo.pk)
+        response = edit_silo(request, silo.pk)
         if response.status_code == 302:
             self.assertEqual(response.url, "/silos/")
         else:

--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -243,7 +243,7 @@ class SiloViewsTest(TestCase, MongoTestCase):
         request = self.factory.get('/silo_edit/{}/'.format(silo.id),
                                    follow=True)
         request.user = self.tola_user.user
-        response = views.editSilo(request, silo.id)
+        response = views.edit_silo(request, silo.id)
         template_content = response.content
 
         match = 'selected>{}</option>'.format(self.tola_user.user.username)
@@ -261,7 +261,7 @@ class SiloViewsTest(TestCase, MongoTestCase):
         request = self.factory.get('/silo_edit/{}/'.format(silo.id),
                                    follow=True)
         request.user = self.tola_user.user
-        response = views.editSilo(request, silo.id)
+        response = views.edit_silo(request, silo.id)
         template_content = response.content
 
         match = 'selected>{}</option>'.format(self.tola_user.user.username)
@@ -280,7 +280,7 @@ class SiloViewsTest(TestCase, MongoTestCase):
 
         request = self.factory.post('/silo_edit/{}/'.format(silo.id), data)
         request.user = self.tola_user.user
-        response = views.editSilo(request, silo.id)
+        response = views.edit_silo(request, silo.id)
         self.assertEqual(response.status_code, 302)
 
         silo = Silo.objects.get(pk=silo.id)
@@ -1322,8 +1322,7 @@ class SiloEditViewTest(TestCase):
                                                    mock_get_workflowteams):
         request_user = factories.User(username='Another User')
         organization = factories.Organization(name='Another Organization')
-        request_tola_user = factories.TolaUser(user=request_user,
-                                               organization=organization)
+        factories.TolaUser(user=request_user, organization=organization)
 
         read = factories.Read(read_name="test_data",
                               owner=self.tola_user.user)
@@ -1335,11 +1334,9 @@ class SiloEditViewTest(TestCase):
                               shared=[],
                               share_with_organization=False)
 
-        url = reverse('editSilo', args=[silo.pk])
-
-        request = self.factory.get(url)
+        request = self.factory.get('')
         request.user = request_user
-        response = views.editSilo(request, silo.pk)
+        response = views.edit_silo(request, silo.pk)
         self.assertEqual(response.status_code, 404)
 
     @patch('silo.forms.get_workflowteams')
@@ -1357,11 +1354,9 @@ class SiloEditViewTest(TestCase):
                               shared=[],
                               share_with_organization=False)
 
-        url = reverse('editSilo', args=[silo.pk])
-
-        request = self.factory.get(url)
+        request = self.factory.get('')
         request.user = self.tola_user.user
-        response = views.editSilo(request, silo.pk)
+        response = views.edit_silo(request, silo.pk)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Silo')
 
@@ -1384,7 +1379,7 @@ class SiloEditViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = request_user
-        response = views.editSilo(request, silo.pk)
+        response = views.edit_silo(request, silo.pk)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Silo')
 
@@ -1392,10 +1387,10 @@ class SiloEditViewTest(TestCase):
     @patch('silo.forms.get_by_url')
     def test_silo_edit_page_with_shared_organizaton_user(self, mock_get_by_url,
                                                    mock_get_workflowteams):
+
         request_user = factories.User(username='Another User')
-        request_tola_user = factories.TolaUser(
-            user=request_user,
-            organization=self.tola_user.organization)
+        factories.TolaUser(user=request_user,
+                           organization=self.tola_user.organization)
 
         read = factories.Read(read_name="test_data",
                               owner=self.tola_user.user)
@@ -1409,7 +1404,7 @@ class SiloEditViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = request_user
-        response = views.editSilo(request, silo.pk)
+        response = views.edit_silo(request, silo.pk)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Silo')
 
@@ -1434,6 +1429,6 @@ class SiloEditViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = request_user
-        response = views.editSilo(request, silo.pk)
+        response = views.edit_silo(request, silo.pk)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Silo')

--- a/silo/views.py
+++ b/silo/views.py
@@ -430,7 +430,7 @@ def appendTwoSilos(mapping_data, lsid, rsid, msid):
 # Edit existing silo meta data
 @csrf_protect
 @login_required
-def editSilo(request, id):
+def edit_silo(request, id):
     """
     Edit the meta data and description for each Table (silo)
     :param request:
@@ -456,7 +456,6 @@ def editSilo(request, id):
                 and request_user_org == owner_user_org)):
         return render(request, '404.html', status=404)
 
-    edited_silo = Silo.objects.get(pk=id)
     if request.method == 'POST':  # If the form has been submitted...
         tags = request.POST.getlist('tags')
         post_data = request.POST.copy()

--- a/silo/views.py
+++ b/silo/views.py
@@ -437,6 +437,25 @@ def editSilo(request, id):
     :param id: Unique table ID
     :return: silo edit form
     """
+
+    edited_silo = Silo.objects.get(pk=id)
+
+    request_user_org = None
+    owner_user_org = None
+    if(hasattr(request.user, 'tola_user') and
+            hasattr(edited_silo.owner, 'tola_user')):
+        request_user_org = request.user.tola_user.organization
+        owner_user_org = edited_silo.owner.tola_user.organization
+
+    is_silo_shared_with_user = Silo.objects.filter(
+        pk=id, shared__id=request.user.pk).exists()
+
+    if not (edited_silo.owner == request.user or edited_silo.public
+            or is_silo_shared_with_user
+            or (edited_silo.share_with_organization
+                and request_user_org == owner_user_org)):
+        return render(request, '404.html', status=404)
+
     edited_silo = Silo.objects.get(pk=id)
     if request.method == 'POST':  # If the form has been submitted...
         tags = request.POST.getlist('tags')

--- a/tola/urls.py
+++ b/tola/urls.py
@@ -56,7 +56,7 @@ urlpatterns =[
 
     url(r'^silos', views.list_silos, name='list_silos'),
     url(r'^silo_detail/(?P<silo_id>\w+)/$', views.silo_detail, name='silo_detail'),
-    url(r'^silo_edit/(?P<id>\w+)/$', views.editSilo, name='editSilo'),
+    url(r'^silo_edit/(?P<id>\w+)/$', views.edit_silo, name='edit_silo'),
     url(r'^silo_delete/(?P<id>\w+)/$', views.deleteSilo, name='deleteSilo'),
     url(r'^add_unique_fields', views.addUniqueFiledsToSilo, name='add_unique_fields_to_silo'),
     url(r'^anonymize_silo/(?P<id>\w+)/$', views.anonymizeTable, name='anonymize_table'),


### PR DESCRIPTION
## Purpose
Users can access silo_edit page via url event if they don't have a permission with that silo.

## Approach
Check for Permissions added to silo_edit  view.

_Related ticket: #487 
