### PR TITLE
Fix special chars issue when handling strings

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,8 @@ import os
 import sys
 
 if __name__ == "__main__":
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 
     if 'test' in sys.argv:
         settings = 'tola.settings.test'

--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -1,8 +1,5 @@
-from django.contrib.auth.models import AnonymousUser
-from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings, Client, RequestFactory
 from django.urls import reverse
-from django.contrib import messages
 
 from rest_framework.test import APIRequestFactory
 
@@ -224,11 +221,9 @@ class SiloViewsTest(TestCase, MongoTestCase):
     @patch('silo.forms.get_by_url')
     def test_get_edit_silo(self, mock_get_by_url, mock_get_workflowteams):
         silo = factories.Silo(owner=self.tola_user.user)
-        uuid = random.randint(1, 9999)
-        wfl1_1 = factories.WorkflowLevel1(level1_uuid=uuid,
+        wfl1_1 = factories.WorkflowLevel1(level1_uuid=random.randint(1, 9999),
                                           name='Workflowlevel1 1')
-        uuid = random.randint(1, 9999)
-        wfl1_2 = factories.WorkflowLevel1(level1_uuid=uuid,
+        wfl1_2 = factories.WorkflowLevel1(level1_uuid=random.randint(1, 9999),
                                           name='Workflowlevel1 2')
         wfteams = [
             {
@@ -386,7 +381,6 @@ class SiloViewsTest(TestCase, MongoTestCase):
 
         self.assertTrue(json_data[0]['farbe'] in ['black', 'white', 'red'])
         self.assertEqual(json_data[0]['art'], 'primary')
-
 
     @patch('silo.views.db')
     def test_silo_edit_columns_delete(self, mock_db):
@@ -875,7 +869,8 @@ class OneDriveViewsTest(TestCase):
 
 class OneDriveReadTest(TestCase):
     new_read_url = '/source/new/'
-    # Is the UserSocialAuth extra data obj updated when there is already one? I saw a test when there is no UserSocialAuth.
+    # Is the UserSocialAuth extra data obj updated when there is already
+    # one? I saw a test when there is no UserSocialAuth.
 
     def setUp(self):
         self.client = Client()
@@ -958,7 +953,7 @@ class OneDriveReadTest(TestCase):
         request.session = 'session'
         message_storage = FallbackStorage(request)
         request._messages = message_storage
-        response = views.showRead(request, 0)
+        views.showRead(request, 0)
 
         messages = []
         for m in message_storage:
@@ -1031,7 +1026,8 @@ class SiloDetailViewTest(TestCase):
         for m in message_storage:
             messages.append(m.message)
 
-        self.assertIn('You do not have permission to view this table.', messages)
+        self.assertIn('You do not have permission to view this table.',
+                      messages)
 
     def test_pulic_silo_detail_with_unshared_user(self):
         read = factories.Read(read_name="test_data",

--- a/tola/wsgi.py
+++ b/tola/wsgi.py
@@ -7,10 +7,13 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 
+import sys
 import os
 
 from django.core.wsgi import get_wsgi_application
 
+reload(sys)
+sys.setdefaultencoding('utf-8')
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tola.settings.local")
 
 application = get_wsgi_application()


### PR DESCRIPTION
## Purpose
The default encoding is `ASCII`, therefore we're having issues when converting/handling strings with special characters in the system. We need to use `UTF-8` instead.

## Approach
- Set `UTF-8` as the default encoding when the system is initialized.

### Furter Info
Related ticket: https://github.com/Humanitec/ActivityAPI/issues/269

https://stackoverflow.com/questions/31137552/unicodeencodeerror-ascii-codec-cant-encode-character-at-special-name#31137935