### PR TITLE
Fix #465 - Make tables shareable with WFL1

### DIFF
--- a/silo/forms.py
+++ b/silo/forms.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from collections import OrderedDict
 
 from silo.models import Read, Silo, WorkflowLevel1
-from tola.activity_proxy import get_by_url, get_workflowteams
+from tola.activity_proxy import get_workflowlevel1s
 
 
 class OnaLoginForm(forms.Form):
@@ -32,17 +32,8 @@ class SiloForm(forms.ModelForm):
         # Filter programs based on the program teams from Activity
         if user:
             self.fields['shared'].queryset = User.objects.exclude(pk=user.pk)
-            params = {
-                'workflow_user__tola_user_uuid': user.tola_user.tola_user_uuid
-            }
-            wfteams = get_workflowteams(**params)
-            wfl1_uuids = []
-            for wfteam in wfteams:
-                if wfteam['workflowlevel1']:
-                    wfl1_url = wfteam['workflowlevel1']
-                    wfl1 = get_by_url(wfl1_url)
-                    if wfl1:
-                        wfl1_uuids.append(wfl1['level1_uuid'])
+
+            wfl1_uuids = get_workflowlevel1s(user)
 
             self.fields['workflowlevel1'].queryset = WorkflowLevel1.objects.\
                 filter(level1_uuid__in=wfl1_uuids)

--- a/silo/tests/test.py
+++ b/silo/tests/test.py
@@ -167,6 +167,7 @@ class SiloDetailTest(TestCase):
         silo.reads.add(read)
         factories.CeleryTask(content_object=read,
                              task_status=CeleryTask.TASK_IN_PROGRESS)
+        factories.TolaUser(user=self.user)
 
         # Check view
 
@@ -196,6 +197,7 @@ class SiloDetailTest(TestCase):
         silo.reads.add(read)
         factories.CeleryTask(content_object=read,
                              task_status=CeleryTask.TASK_FAILED)
+        factories.TolaUser(user=self.user)
 
         # Check view
         request = self.factory.get(self.silo_detail_url)
@@ -225,7 +227,7 @@ class SiloDetailTest(TestCase):
         silo.reads.add(read)
         factories.CeleryTask(content_object=read,
                              task_status=CeleryTask.TASK_FINISHED)
-
+        factories.TolaUser(user=self.user)
         # Check view
         request = self.factory.get(self.silo_detail_url)
         request.user = self.user
@@ -300,7 +302,7 @@ class SiloTest(TestCase):
         self.tola_user = factories.TolaUser()
         factories.ReadType.create_batch(7)
 
-    @patch('silo.forms.get_workflowteams')
+    @patch('tola.activity_proxy.get_workflowteams')
     def test_new_silo(self, mock_get_workflowteams):
         mock_get_workflowteams.return_value = []
         # Create a New Silo
@@ -328,7 +330,7 @@ class SiloTest(TestCase):
         else:
             self.assertEqual(response.status_code, 200)
 
-    @patch('silo.forms.get_workflowteams')
+    @patch('tola.activity_proxy.get_workflowteams')
     def test_new_silodata(self, mock_get_workflowteams):
         mock_get_workflowteams.return_value = []
         read_type = ReadType.objects.get(read_type="CSV")

--- a/silo/tests/test_forms.py
+++ b/silo/tests/test_forms.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from django.test import TestCase
-from django.urls import reverse
 
 from mock import patch
 

--- a/silo/views.py
+++ b/silo/views.py
@@ -48,6 +48,7 @@ from .tasks import process_silo
 
 from django.contrib.contenttypes.models import ContentType
 from social_django.models import UserSocialAuth
+from tola.activity_proxy import get_workflowlevel1s
 
 logger = logging.getLogger("silo")
 client = MongoClient(settings.MONGO_URI)
@@ -439,16 +440,18 @@ def edit_silo(request, id):
     """
 
     edited_silo = Silo.objects.get(pk=id)
-
+    user_wfl1s = get_workflowlevel1s(request.user)
     request_user_org = None
     owner_user_org = None
+
     if(hasattr(request.user, 'tola_user') and
             hasattr(edited_silo.owner, 'tola_user')):
         request_user_org = request.user.tola_user.organization
         owner_user_org = edited_silo.owner.tola_user.organization
 
     is_silo_shared_with_user = Silo.objects.filter(
-        pk=id, shared__id=request.user.pk).exists()
+        Q(pk=id, shared__id=request.user.pk) |
+        Q(pk=id, workflowlevel1__level1_uuid__in=user_wfl1s)).exists()
 
     if not (edited_silo.owner == request.user or edited_silo.public
             or is_silo_shared_with_user
@@ -944,15 +947,17 @@ def list_silos(request):
     Each silo is listed with links to details
     """
     user = User.objects.get(username__exact=request.user)
+    user_wfl1s = get_workflowlevel1s(user)
 
     # get all of the silos
     own_silos = Silo.objects.filter(owner=user).prefetch_related('reads')
 
-    shared_silos = Silo.objects.filter(Q(shared__id=user.pk) |
-                                       Q(share_with_organization=True,
-                                         owner__tola_user__organization=\
-                                         user.tola_user.organization))\
-        .exclude(owner=user).prefetch_related("reads")
+    shared_silos = Silo.objects.filter(
+        Q(shared__id=user.pk) |
+        Q(share_with_organization=True,
+          owner__tola_user__organization=user.tola_user.organization) |
+        Q(workflowlevel1__level1_uuid__in=user_wfl1s)).\
+        exclude(owner=user).prefetch_related("reads")
 
     public_silos = Silo.objects.filter(
         Q(public=True) & ~Q(owner=user)).prefetch_related("reads")
@@ -1017,6 +1022,7 @@ def silo_detail(request, silo_id):
     """
 
     silo = Silo.objects.get(pk=silo_id)
+    user_wfl1s = get_workflowlevel1s(request.user)
     cols = []
     query = makeQueryForHiddenRow(json.loads(silo.rows_to_hide))
 
@@ -1048,22 +1054,26 @@ def silo_detail(request, silo_id):
         celery_tasks
     )
 
-    request_user_org=None
-    owner_user_org=None
-    if(hasattr(request.user, 'tola_user') and hasattr(silo.owner,'tola_user')):
+    request_user_org = None
+    owner_user_org = None
+    if hasattr(request.user, 'tola_user') and hasattr(silo.owner, 'tola_user'):
         request_user_org = request.user.tola_user.organization
         owner_user_org = silo.owner.tola_user.organization
 
+    is_silo_shared_with_user = Silo.objects.filter(
+        Q(pk=silo_id, shared__id=request.user.pk) |
+        Q(pk=silo_id, workflowlevel1__level1_uuid__in=user_wfl1s)).exists()
+
     if (silo.owner == request.user or silo.public
-            or request.user in silo.shared.all()
+            or is_silo_shared_with_user
             or (silo.share_with_organization
                 and request_user_org == owner_user_org)):
         cols.append('_id')
         cols.append('id')
         cols.extend(getSiloColumnNames(silo_id))
     else:
-        messages.warning(request,
-                         "You do not have permission to view this table.")
+        messages.error(request,
+                       "You do not have permission to view this table.")
     return render(
         request,
         "display/silo.html",

--- a/tola/activity_proxy.py
+++ b/tola/activity_proxy.py
@@ -4,6 +4,7 @@ import json
 from urlparse import urljoin
 
 from django.conf import settings
+from requests.exceptions import MissingSchema
 
 logger = logging.getLogger(__name__)
 
@@ -70,5 +71,5 @@ def get_workflowlevel1s(user):
                 if wfl1:
                     wfl1_uuids.append(wfl1['level1_uuid'])
         return wfl1_uuids
-    except Exception:
+    except MissingSchema:
         return []

--- a/tola/activity_proxy.py
+++ b/tola/activity_proxy.py
@@ -49,9 +49,26 @@ def get_by_url(url):
     headers = _get_headers()
     response = requests.get(url, headers=headers)
     content = {}
-
     if response.status_code == 200:
         content = json.loads(response.content)
     else:
         logger.warn('{}: {}'.format(response.status_code, response.content))
     return content
+
+
+def get_workflowlevel1s(user):
+    try:
+        params = {
+            'workflow_user__tola_user_uuid': user.tola_user.tola_user_uuid,
+            'nested_models': True
+        }
+        wfteams = get_workflowteams(**params)
+        wfl1_uuids = []
+        for wfteam in wfteams:
+            if wfteam['workflowlevel1']:
+                wfl1 = wfteam['workflowlevel1']
+                if wfl1:
+                    wfl1_uuids.append(wfl1['level1_uuid'])
+        return wfl1_uuids
+    except Exception:
+        return []


### PR DESCRIPTION
## Purpose
User wants to share their tables with their workflowlevel1s.

## Approach
Workflow checks added to silo_edit, silo_detail and list_silo views.

_Related ticket: #465 
