### PR TITLE
Filter list of shared users by Org

### DIFF
--- a/silo/tests/test_forms.py
+++ b/silo/tests/test_forms.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+from django.urls import reverse
+
+from mock import patch
+
+import factories
+from silo import forms
+
+
+class SiloFormTest(TestCase):
+    def setUp(self):
+        self.user = factories.User()
+        self.tola_user = factories.TolaUser(user=self.user)
+
+    def test_form_form_fields(self):
+        form_fields = ['name', 'description', 'tags', 'shared',
+                       'share_with_organization', 'owner', 'workflowlevel1']
+        form = forms.SiloForm()
+
+        self.assertItemsEqual(form_fields, form.fields.keys())
+
+    def test_form_no_data(self):
+        silo = factories.Silo()
+        data = {}
+        form = forms.SiloForm(data=data, instance=silo)
+
+        self.assertTrue(form.has_changed())
+        self.assertEqual(form.data, {})
+
+    def test_form_with_data(self):
+        silo = factories.Silo()
+        data = {'name': 'This is the new name'}
+        form = forms.SiloForm(data=data, instance=silo)
+
+        self.assertTrue(form.has_changed())
+        self.assertEqual(form.data, data)
+
+    @patch('silo.forms.get_workflowteams')
+    @patch('silo.forms.get_by_url')
+    def test_form_with_wfl1(self, mock_get_by_url, mock_get_workflowteams):
+        wfl1 = factories.WorkflowLevel1()
+        wfl1_url = reverse('workflowlevel1-detail', kwargs={'pk': wfl1.id})
+
+        workflowteams = [{'workflowlevel1': wfl1_url}]
+        mock_get_workflowteams.return_value = workflowteams
+        mock_get_by_url.return_value = wfl1.__dict__
+        form = forms.SiloForm(user=self.user)
+
+        item = form.fields.__getitem__('workflowlevel1')
+        queryset = item._queryset
+
+        self.assertEqual(queryset.count(), 1)
+        self.assertTrue(queryset.filter(pk=wfl1.id).exists())
+
+    @patch('silo.forms.get_workflowteams')
+    @patch('silo.forms.get_by_url')
+    def test_form_without_wfl1(self, mock_get_by_url, mock_get_workflowteams):
+        workflowteams = [{'workflowlevel1': ''}]
+        mock_get_workflowteams.return_value = workflowteams
+        mock_get_by_url.return_value = []
+        form = forms.SiloForm(user=self.user)
+
+        item = form.fields.__getitem__('workflowlevel1')
+        queryset = item._queryset
+
+        self.assertEqual(queryset.count(), 0)
+
+    @patch('silo.forms.get_workflowteams')
+    def test_form_validate_success_with_form_user(self,
+                                                  mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        silo = factories.Silo(owner=self.user)
+        data = {
+            'name': silo.name,
+            'owner': silo.owner.id,
+        }
+        form = forms.SiloForm(user=self.user, data=data, instance=silo)
+
+        self.assertTrue(form.is_valid())
+
+    def test_form_validate_success_without_form_user_and_shared(self):
+        silo = factories.Silo(owner=self.user)
+        data = {
+            'name': silo.name,
+            'owner': silo.owner.id,
+        }
+        form = forms.SiloForm(data=data, instance=silo)
+
+        self.assertTrue(form.is_valid())
+
+    @patch('silo.forms.get_workflowteams')
+    def test_form_validate_success_shared(self, mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        user = factories.User(first_name='Homer', last_name='Simpson')
+        factories.TolaUser(
+            user=user, organization=self.tola_user.organization)
+        silo = factories.Silo(owner=self.user)
+
+        data = {
+            'name': silo.name,
+            'owner': silo.owner.id,
+            'shared': [user.id],
+        }
+        form = forms.SiloForm(user=self.user, data=data, instance=silo)
+
+        self.assertTrue(form.is_valid())
+
+    @patch('silo.forms.get_workflowteams')
+    def test_form_validate_fail_shared_diff_org(self, mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        user = factories.User(first_name='Homer', last_name='Simpson')
+        factories.TolaUser(user=user)
+        silo = factories.Silo(owner=self.user)
+
+        data = {
+            'name': silo.name,
+            'owner': silo.owner.id,
+            'shared': [user.id],
+        }
+        form = forms.SiloForm(user=self.user, data=data, instance=silo)
+
+        self.assertFalse(form.is_valid())
+
+    @patch('silo.forms.get_workflowteams')
+    def test_form_validate_fail_shared_with_owner(self,
+                                                  mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        silo = factories.Silo(owner=self.user)
+        data = {
+            'name': silo.name,
+            'owner': silo.owner.id,
+            'shared': [silo.owner.id],
+        }
+        # with user
+        form = forms.SiloForm(user=self.user, data=data, instance=silo)
+        self.assertFalse(form.is_valid())
+
+        # without user
+        form = forms.SiloForm(data=data, instance=silo)
+        self.assertFalse(form.is_valid())
+
+    @patch('silo.forms.get_workflowteams')
+    def test_form_validate_fail_without_owner(self, mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        silo = factories.Silo(owner=self.user)
+        data = {
+            'name': silo.name,
+            'shared': [self.user.id],
+        }
+
+        form = forms.SiloForm(user=self.user, data=data, instance=silo)
+        self.assertFalse(form.is_valid())
+
+    @patch('silo.forms.get_workflowteams')
+    def test_form_validate_fail_without_form_user(self,
+                                                  mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        user = factories.User(first_name='Homer', last_name='Simpson')
+        factories.TolaUser(
+            user=user, organization=self.tola_user.organization)
+        silo = factories.Silo(owner=self.user)
+
+        data = {
+            'name': silo.name,
+            'owner': silo.owner.id,
+            'shared': [user.id],
+        }
+        form = forms.SiloForm(data=data, instance=silo)
+        self.assertFalse(form.is_valid())

--- a/silo/views.py
+++ b/silo/views.py
@@ -474,7 +474,8 @@ def edit_silo(request, id):
 
                 post_data.appendlist('tags', tag.id)
 
-        form = SiloForm(data=post_data, instance=edited_silo)
+        form = SiloForm(user=request.user, data=post_data,
+                        instance=edited_silo)
         if form.is_valid():
             form.save()
             return HttpResponseRedirect('/silos/')


### PR DESCRIPTION
## Purpose
In the "Shared" drop-down we need to filter the list of users to only users in one's Org.

## Approach
- I had to update the Silo's form to filter the list of users
- I had to update the cleaning function as well, so it won't accept users from other orgs an so on.

### Furter Info
Related ticket: #495 
