### PR TITLE
Fix #500 - add permissions to reports list view

### DIFF
--- a/reports/tests.py
+++ b/reports/tests.py
@@ -30,7 +30,7 @@ class ReportsViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = self.user
-        response = views.listTableDashboards(request)
+        response = views.list_table_dashboards(request)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Report')
 
@@ -47,7 +47,7 @@ class ReportsViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = self.tola_user.user
-        response = views.listTableDashboards(request)
+        response = views.list_table_dashboards(request)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Report')
 
@@ -68,7 +68,7 @@ class ReportsViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = request_user
-        response = views.listTableDashboards(request)
+        response = views.list_table_dashboards(request)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Report')
 
@@ -87,7 +87,7 @@ class ReportsViewTest(TestCase):
                        share_with_organization=True)
         request = self.factory.get('')
         request.user = request_user
-        response = views.listTableDashboards(request)
+        response = views.list_table_dashboards(request)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'Test Share Report')
 
@@ -108,7 +108,7 @@ class ReportsViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = request_user
-        response = views.listTableDashboards(request)
+        response = views.list_table_dashboards(request)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'Test Share Report')
 
@@ -127,7 +127,7 @@ class ReportsViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = self.user
-        response = views.listTableDashboards(request)
+        response = views.list_table_dashboards(request)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Report')
 
@@ -147,6 +147,6 @@ class ReportsViewTest(TestCase):
 
         request = self.factory.get('')
         request.user = request_user
-        response = views.listTableDashboards(request)
+        response = views.list_table_dashboards(request)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Share Report')

--- a/reports/tests.py
+++ b/reports/tests.py
@@ -1,4 +1,7 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+import factories
+from rest_framework.test import APIRequestFactory
+from reports import views
 
 
 class SimpleTest(TestCase):
@@ -7,3 +10,143 @@ class SimpleTest(TestCase):
         Tests that 1 + 1 always equals 2.
         """
         self.assertEqual(1 + 1, 2)
+
+class ReportsViewTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = factories.User()
+        self.tola_user = factories.TolaUser(user=self.user)
+
+    def test_list_own_reports(self):
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        factories.Silo(name='Test Share Report',
+                       owner=self.tola_user.user,
+                       reads=[read],
+                       public=False,
+                       shared=[],
+                       share_with_organization=True)
+
+        request = self.factory.get('')
+        request.user = self.user
+        response = views.listTableDashboards(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test Share Report')
+
+    def test_list_reports_shared_with_organization(self):
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        factories.Silo(name='Test Share Report',
+                       owner=self.tola_user.user,
+                       reads=[read],
+                       public=False,
+                       shared=[],
+                       share_with_organization=True)
+
+        request = self.factory.get('')
+        request.user = self.tola_user.user
+        response = views.listTableDashboards(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test Share Report')
+
+    def test_list_reports_shared_with_users_organization(self):
+        request_user = factories.User(username='Another User')
+        factories.TolaUser(user=request_user,
+                           organization=self.tola_user.organization)
+
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        factories.Silo(name='Test Share Report',
+                       owner=self.tola_user.user,
+                       reads=[read],
+                       public=False,
+                       shared=[],
+                       share_with_organization=True)
+
+        request = self.factory.get('')
+        request.user = request_user
+        response = views.listTableDashboards(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test Share Report')
+
+    def test_list_reports_shared_with_different_organization(self):
+        request_user = factories.User(username='Another User')
+        factories.TolaUser(user=request_user)
+
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        factories.Silo(name='Test Share Report',
+                       owner=self.tola_user.user,
+                       reads=[read],
+                       public=False,
+                       shared=[],
+                       share_with_organization=True)
+        request = self.factory.get('')
+        request.user = request_user
+        response = views.listTableDashboards(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Test Share Report')
+
+    def test_list_reports_not_share_with_organization(self):
+        request_user = factories.User(username='Another User')
+        factories.TolaUser(user=request_user,
+                           organization=self.tola_user.organization)
+
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        factories.Silo(name='Test Share Report',
+                       owner=self.tola_user.user,
+                       reads=[read],
+                       public=False,
+                       shared=[],
+                       share_with_organization=False)
+
+        request = self.factory.get('')
+        request.user = request_user
+        response = views.listTableDashboards(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Test Share Report')
+
+    def test_list_reports_with_shared_user(self):
+
+        request_user = factories.User(username='Another User')
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        factories.Silo(name='Test Share Report',
+                       owner=self.tola_user.user,
+                       reads=[read],
+                       public=False,
+                       shared=[request_user],
+                       share_with_organization=False)
+
+        request = self.factory.get('')
+        request.user = self.user
+        response = views.listTableDashboards(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test Share Report')
+
+    def test_list_public_reports(self):
+        request_user = factories.User(username='Another User')
+        factories.TolaUser(user=request_user)
+
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        factories.Silo(name='Test Share Report',
+                       owner=self.tola_user.user,
+                       reads=[read],
+                       public=True,
+                       shared=[],
+                       share_with_organization=False)
+
+        request = self.factory.get('')
+        request.user = request_user
+        response = views.listTableDashboards(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test Share Report')

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -6,9 +6,9 @@ from django.conf.urls import *
 # place app url patterns here
 
 urlpatterns = [
-
        #display public custom dashboard
-       url(r'^table_list/$', reports.views.listTableDashboards, name='table_dashboard_list'),
-       url(r'^table_dashboard/(?P<id>\w+)/$', reports.views.tableDashboard, name='table_dashboard'),
-
+       url(r'^table_list/$', reports.views.list_table_dashboards,
+           name='table_dashboard_list'),
+       url(r'^table_dashboard/(?P<id>\w+)/$',
+           reports.views.table_dashboard, name='table_dashboard'),
 ]

--- a/reports/views.py
+++ b/reports/views.py
@@ -12,13 +12,19 @@ import logging
 logger = logging.getLogger('django')
 
 
-def listTableDashboards(request,id=0):
+def listTableDashboards(request, id=0):
 
     user = User.objects.get(username__exact=request.user)
     tola_user = TolaUser.objects.get(user__username__exact=request.user)
-    get_tables = Silo.objects.filter(Q(owner=user) | Q(organization=tola_user.organization) | Q(shared=user))
 
-    return render(request, "reports/table_list.html", {'get_tables': get_tables})
+    get_tables = Silo.objects.filter(
+        Q(owner=user) | Q(shared=user) | Q(public=True) |
+        Q(owner__tola_user__organization=tola_user.organization,
+          share_with_organization=True))
+
+    return render(request,
+                  "reports/table_list.html",
+                  {'get_tables': get_tables})
 
 
 import itertools

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,18 +1,21 @@
 from django.shortcuts import render
 from silo.models import Country, Silo, User, TolaUser, LabelValueStore, UniqueFields
 from django.db.models import Q
-
+from django.utils.safestring import SafeString
+from collections import Counter
+import unicodedata
 import json
 import ast
 
 # import the logging library
 import logging
+import itertools
 
 # Get an instance of a logger
 logger = logging.getLogger('django')
 
 
-def listTableDashboards(request, id=0):
+def list_table_dashboards(request, id=0):
 
     user = User.objects.get(username__exact=request.user)
     tola_user = TolaUser.objects.get(user__username__exact=request.user)
@@ -23,14 +26,10 @@ def listTableDashboards(request, id=0):
           share_with_organization=True))
 
     return render(request,
-                  "reports/table_list.html",
-                  {'get_tables': get_tables})
+                  "reports/table_list.html", {'get_tables': get_tables})
 
 
-import itertools
-
-
-def tableDashboard(request,id=0):
+def table_dashboard(request,id=0):
     """
     Dynamic Dashboard report based on Table Data
     find lat and long fields
@@ -51,7 +50,6 @@ def tableDashboard(request,id=0):
     except ValueError:
         data = json.loads(doc)
 
-    from collections import Counter
     latitude = []
     longitude = []
     lat_long = {}
@@ -63,25 +61,31 @@ def tableDashboard(request,id=0):
         # loop over the field names only
         for field in data[0]:
             # to-do move these into models
-            exclude_string = ['read_id','silo_id','_id','formhub/uuid','meta/instanceID','user_assigned_id','meta/instanceName','create_date']
+            exclude_string = ['read_id', 'silo_id', '_id', 'formhub/uuid',
+                              'meta/instanceID', 'user_assigned_id',
+                              'meta/instanceName', 'create_date']
             map_lat_string = ['lat', 'latitude', 'x']
-            map_long_string = ['long','lng','longitude', 'y']
-            map_country_string = ['countries','country']
-            map_location = ['location', 'coordinated','coord']
+            map_long_string = ['long', 'lng', 'longitude', 'y']
+            map_country_string = ['countries', 'country']
+            map_location = ['location', 'coordinated', 'coord']
             if field not in exclude_string:
-                get_fields[field] = {} # create a dict with fields as the key
+                # create a dict with fields as the key
+                get_fields[field] = {}
                 cnt = Counter()
                 answers = [] # a list for the answers
                 for idx, col in enumerate(data):
-                    # get_fields[field][idx] = col[field] # append list of all answers
+                    # get_fields[field][idx] = col[field]
+                    #  append list of all answers
                     try:
-                        answers.append(col[field]) # append list of answers
+                        # append list of answers
+                        answers.append(col[field])
                     except KeyError:
                         answers.append(None)  # no answer
                 # loop and count each unique answer
                 """
-                TODO: Needs to be moved to a recursive function that checks each level for
-                list or dict and continues to parse until a count can be found
+                TODO: Needs to be moved to a recursive function that checks each
+                 level for list or dict and continues to parse until a count 
+                 can be found
                 """
                 for a in answers:
                     # if answer has a dict or list count each element
@@ -103,15 +107,14 @@ def tableDashboard(request,id=0):
                 # append unique answer plus count to dict
                 get_fields[field][idx] = unique_count.most_common()
 
-                from django.utils.safestring import SafeString
-                import unicodedata
-
                 temp = []
                 temp2 = []
                 for letter, count in get_fields[field][idx]:
 
                     if isinstance(letter,unicode):
-                        temp.append(SafeString(unicodedata.normalize('NFKD', letter).encode('ascii', 'ignore')))
+                        temp.append(SafeString(unicodedata.normalize('NFKD',
+                                                                     letter)
+                                               .encode('ascii', 'ignore')))
                     else:
                         temp.append(letter)
                     temp2.append(count)
@@ -122,8 +125,8 @@ def tableDashboard(request,id=0):
                 except ValueError:
                     temp = temp
 
-                get_fields[field][idx] = {"label": SafeString(temp), "count": SafeString(temp2)}
-
+                get_fields[field][idx] = {"label": SafeString(temp),
+                                          "count": SafeString(temp2)}
 
             # if a latitude string add it to the map list
             if field in map_lat_string:
@@ -138,8 +141,10 @@ def tableDashboard(request,id=0):
             # if a longitude string add it to the map list
             if field in map_location:
                 for idx, col in enumerate(data):
-                    latitude.append(itertools.islice(col[field].iteritems(), 3, 4))
-                    longitude.append(itertools.islice(col[field].iteritems(), 4, 5))
+                    latitude.append(itertools.islice(col[field].iteritems(),
+                                                     3, 4))
+                    longitude.append(itertools.islice(col[field].iteritems(),
+                                                      4, 5))
 
             # if a country name
             if field in map_country_string:
@@ -151,7 +156,6 @@ def tableDashboard(request,id=0):
 
             # merge lat and long
             lat_long = dict(zip(latitude,longitude))
-
     else:
         get_fields = None
 
@@ -161,10 +165,6 @@ def tableDashboard(request,id=0):
         columns = json.loads(get_table.columns)
 
     return render(request, "reports/table_dashboard.html",
-                  {'data': data, 'get_table': get_table, 'countries': countries, 'get_fields': get_fields,
-                   'lat_long': lat_long,'country': country, 'columns': columns})
-
-
-
-
-
+                  {'data': data, 'get_table': get_table, 'countries': countries,
+                   'get_fields': get_fields,'lat_long': lat_long,
+                   'country': country, 'columns': columns})


### PR DESCRIPTION
## Purpose
Currently users can see all reports in their organization event if reports aren't shared with them. Prevent users from accessing reports which they haven't permissions 

## Approach
New permissions added to reports list view.

_Related ticket: #500 
