### PR TITLE
fix #499 - add permissions to changing publicity of table

### DIFF
--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -1285,6 +1285,47 @@ class SiloDetailViewTest(TestCase):
         self.assertIn("You do not have permission to view this table.",
                       messages)
 
+    def test_silo_detail_change_publicty_owner(self):
+
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        silo = factories.Silo(name='Test Share Silo',
+                              owner=self.tola_user.user,
+                              reads=[read],
+                              public=False,
+                              shared=[],
+                              share_with_organization=True)
+
+        request = self.factory.get('/toggle_silo_publicity/?silo_id={}'
+                                   .format(silo.pk))
+        request.user = self.user
+        response = views.toggle_silo_publicity(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, 'Your change has been saved')
+
+    def test_silo_detail_change_publicty_not_owner(self):
+
+        request_user = factories.User(username='Another User')
+        factories.TolaUser(user=request_user)
+        read = factories.Read(read_name="test_data",
+                              owner=self.tola_user.user)
+
+        silo = factories.Silo(name='Test Share Silo',
+                              owner=self.tola_user.user,
+                              reads=[read],
+                              public=False,
+                              shared=[],
+                              share_with_organization=True)
+
+        request = self.factory.get('/toggle_silo_publicity/?silo_id={}'
+                                   .format(silo.pk))
+        request.user = request_user
+        response = views.toggle_silo_publicity(request)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.content,
+                         'You can not  change publicity of this table')
+
 
 class SiloListViewTest(TestCase):
     def setUp(self):

--- a/silo/views.py
+++ b/silo/views.py
@@ -936,9 +936,14 @@ def getJSON(request):
 def toggle_silo_publicity(request):
     silo_id = request.GET.get('silo_id', None)
     silo = Silo.objects.get(pk=silo_id)
-    silo.public = not silo.public
-    silo.save()
-    return HttpResponse("Your change has been saved")
+
+    if silo.owner == request.user:
+        silo.public = not silo.public
+        silo.save()
+        return HttpResponse('Your change has been saved', status=200)
+    else:
+        return HttpResponse('You can not  change publicity of this table',
+                            status=403)
 
 
 # SILOS


### PR DESCRIPTION
## Purpose
The user can 'view/edit' any public table, but the cannot make it private.
The user is only able to change a table to public or private if they are the owner.

## Approach
Owner check added to toggle_silo_publicity view.

_Related ticket: #499 
