### PR TITLE
Fix #494 - add permissions to change owner functionality

### DIFF
--- a/silo/forms.py
+++ b/silo/forms.py
@@ -46,6 +46,10 @@ class SiloForm(forms.ModelForm):
             self.fields['workflowlevel1'].queryset = WorkflowLevel1.objects.\
                 filter(level1_uuid__in=wfl1_uuids)
 
+            if hasattr(self.instance, 'owner') and \
+                    not (user == self.instance.owner):
+                self.fields.pop('owner')
+
         # If you pass FormHelper constructor a form instance
         # It builds a default layout with all its fields
         self.helper = FormHelper(self)
@@ -62,7 +66,6 @@ class SiloForm(forms.ModelForm):
         shared = self.cleaned_data['shared']
         owner = self.data.get('owner')
         valid = True
-
         if owner and shared:
             if self.user:
                 organization_id = TolaUser.objects.values_list(
@@ -78,9 +81,14 @@ class SiloForm(forms.ModelForm):
             else:
                 valid = False
 
+        if owner and self.user:
+            if hasattr(self.instance, 'owner') and \
+                     self.instance.owner.pk != owner \
+                    and self.user != self.instance.owner:
+                valid = False
+
         if not valid:
             raise ValidationError('The form provided is invalid.')
-
         return shared
 
 

--- a/silo/tests/test_forms.py
+++ b/silo/tests/test_forms.py
@@ -164,3 +164,40 @@ class SiloFormTest(TestCase):
         }
         form = forms.SiloForm(data=data, instance=silo)
         self.assertFalse(form.is_valid())
+
+    @patch('tola.activity_proxy.get_workflowteams')
+    def test_form_validate_success_change_owner(self,
+                                                mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        user = factories.User(first_name='Homer', last_name='Simpson')
+        factories.TolaUser(
+            user=user, organization=self.tola_user.organization)
+        silo = factories.Silo(owner=self.user)
+
+        data = {
+            'name': silo.name,
+            'owner': user.id,
+        }
+        form = forms.SiloForm(user=self.user, data=data, instance=silo)
+        self.assertTrue(form.is_valid())
+
+    @patch('tola.activity_proxy.get_workflowteams')
+    def test_form_validate_fail_change_owner(self,
+                                             mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        user = factories.User(first_name='Homer', last_name='Simpson')
+        factories.TolaUser(
+            user=user, organization=self.tola_user.organization)
+
+        another_user = factories.User(username='Another User')
+        factories.TolaUser(user=another_user)
+
+        silo = factories.Silo(owner=self.user)
+
+        data = {
+            'name': silo.name,
+            'owner': another_user,
+            'shared': [user.id],
+        }
+        form = forms.SiloForm(user=another_user, data=data, instance=silo)
+        self.assertFalse(form.is_valid())


### PR DESCRIPTION
## Purpose
Other users (If they are not owner) can't change owner of the table.

## Approach
Permissions checks added to silo form validation.

_Related ticket: #494 
