### PR TITLE
Fix #505 - filter users by org for owner selectbox

### DIFF
--- a/silo/forms.py
+++ b/silo/forms.py
@@ -33,15 +33,16 @@ class SiloForm(forms.ModelForm):
         # Filter programs based on the program teams from Activity
         self.user = user
         if user:
-            self.fields['shared'].queryset = User.objects.exclude(pk=user.pk)
-
             wfl1_uuids = get_workflowlevel1s(user)
 
             organization_id = TolaUser.objects.\
                 values_list('organization_id', flat=True).get(user=user)
-            self.fields['shared'].queryset = User.objects.\
-                filter(tola_user__organization_id=organization_id).\
-                exclude(pk=user.pk)
+
+            user_queryset = User.objects.\
+                filter(tola_user__organization_id=organization_id)
+
+            self.fields['shared'].queryset = user_queryset.exclude(pk=user.pk)
+            self.fields['owner'].queryset = user_queryset
 
             self.fields['workflowlevel1'].queryset = WorkflowLevel1.objects.\
                 filter(level1_uuid__in=wfl1_uuids)

--- a/silo/tests/test_forms.py
+++ b/silo/tests/test_forms.py
@@ -201,3 +201,23 @@ class SiloFormTest(TestCase):
         }
         form = forms.SiloForm(user=another_user, data=data, instance=silo)
         self.assertFalse(form.is_valid())
+
+    @patch('tola.activity_proxy.get_workflowteams')
+    def test_form_validate_fail_owner_from_diff_org(self,
+                                                    mock_get_workflowteams):
+        mock_get_workflowteams.return_value = []
+        user = factories.User(first_name='Homer', last_name='Simpson')
+        factories.TolaUser(user=user,
+                           organization=self.tola_user.organization)
+        another_user = factories.User(username='Another User')
+        factories.TolaUser(user=another_user)
+        silo = factories.Silo(owner=self.user)
+
+        data = {
+            'name': silo.name,
+            'owner': another_user.id,
+            'shared': [user.id],
+        }
+        form = forms.SiloForm(user=self.user, data=data, instance=silo)
+
+        self.assertFalse(form.is_valid())


### PR DESCRIPTION
## Purpose
When users want to change owner of the table, they want to see list of users from their organization.

## Approach
Filter by organizations added to user list for owner selectbox

_Related ticket: #505 
