### PR TITLE
Add date column and value to custom forms

### DIFF
--- a/silo/api.py
+++ b/silo/api.py
@@ -138,6 +138,10 @@ class CustomFormViewSet(mixins.CreateModelMixin,
                         viewsets.GenericViewSet):
     serializer_class = CustomFormSerializer
     queryset = Silo.objects.all()
+    _default_columns = [
+        {'name': 'submission_data', 'type': 'date'},
+        {'name': 'submission_time', 'type': 'date'}
+    ]
 
     def create(self, request, *args, **kwargs):
         """
@@ -157,7 +161,7 @@ class CustomFormViewSet(mixins.CreateModelMixin,
         form_name = serializer.data['name']
         read_name = serializer.data['name']
         columns = serializer.data['fields']
-        columns.append({'name': 'submission_time', 'type': 'time'})
+        columns += self._default_columns
         description = serializer.data.get('description', '')
 
         # we need to convert the dict into a JSON to be stored
@@ -261,8 +265,12 @@ class CustomFormViewSet(mixins.CreateModelMixin,
                             status=status.HTTP_400_BAD_REQUEST)
 
         if data:
-            submission_date = datetime.now().strftime('%H:%M:%S')
-            data.update({'submission_time': submission_date})
+            # add the timestamp
+            now = datetime.now()
+            submission_date = now.strftime('%Y-%m-%d')
+            submission_time = now.strftime('%H:%M:%S')
+            data.update({'submission_date': submission_date})
+            data.update({'submission_time': submission_time})
 
         try:
             silo = Silo.objects.get(pk=silo_id)

--- a/silo/tests/test_customformview.py
+++ b/silo/tests/test_customformview.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from datetime import datetime
 from urlparse import urljoin
 
 from django.conf import settings
@@ -130,7 +131,7 @@ class CustomFormCreateViewTest(TestCase, MongoTestCase):
         silo_id = response.data['id']
         silo = Silo.objects.get(pk=silo_id)
         form_name = '{} - {}'.format(data['name'], wflvl1.name)
-        fields.append({'name': 'submission_time', 'type': 'time'})
+        fields += CustomFormViewSet._default_columns
         level1_uuids = silo.workflowlevel1.values_list(
             'level1_uuid', flat=True).all()
 
@@ -447,7 +448,8 @@ class CustomFormSaveDataViewTest(TestCase):
             columns='[{"name": "name", "type": "text"},'
                     '{"name": "age", "type": "number"},'
                     '{"name": "city", "type": "text"},'
-                    '{"name": "submission_time", "type": "time"}]',
+                    '{"name": "submission_data", "type": "date"},'
+                    '{"name": "submission_time", "type": "date"}]',
             reads=[self.read],
             public=False
         )
@@ -561,6 +563,12 @@ class CustomFormSaveDataViewTest(TestCase):
         self.assertEqual(data['name'], 'John Lennon')
         self.assertEqual(data['age'], 40)
         self.assertEqual(data['city'], 'Liverpool')
+
+        # check the submission date
+        submission_date = datetime.now().strftime('%Y-%m-%d')
+        self.assertIn('submission_date', data)
+        self.assertEqual(data['submission_date'], submission_date)
+
         # the time can be different if the request takes a while
         self.assertIn('submission_time', data)
         self.assertTrue(data['submission_time'])


### PR DESCRIPTION
## Purpose
When a user creates a form in Activity and publishes it, they would like the table created in Track to have a submission date for each entry.

## Approach
- I appended the new column to the given ones
- I always add the date when a new data is sent to be saved

### Furter Info
Related ticket: #480 
