### PR TITLE
Add submitted by info to custom forms

### DIFF
--- a/silo/api.py
+++ b/silo/api.py
@@ -139,6 +139,7 @@ class CustomFormViewSet(mixins.CreateModelMixin,
     serializer_class = CustomFormSerializer
     queryset = Silo.objects.all()
     _default_columns = [
+        {'name': 'submitted_by', 'type': 'text'},
         {'name': 'submission_data', 'type': 'date'},
         {'name': 'submission_time', 'type': 'date'}
     ]
@@ -260,6 +261,7 @@ class CustomFormViewSet(mixins.CreateModelMixin,
         if 'silo_id' in request.data and 'data' in request.data:
             silo_id = request.data['silo_id']
             data = request.data['data']
+            submitted_by_uuid = request.data.get('submitted_by', None)
         else:
             return Response({'detail': 'Missing data.'},
                             status=status.HTTP_400_BAD_REQUEST)
@@ -271,6 +273,12 @@ class CustomFormViewSet(mixins.CreateModelMixin,
             submission_time = now.strftime('%H:%M:%S')
             data.update({'submission_date': submission_date})
             data.update({'submission_time': submission_time})
+
+            # if there's a submitted_by uuid, add the user's name to the data
+            if submitted_by_uuid:
+                submitted_by_username = TolaUser.objects.values_list(
+                    'name', flat=True).get(tola_user_uuid=submitted_by_uuid)
+                data.update({'submitted_by': submitted_by_username})
 
         try:
             silo = Silo.objects.get(pk=silo_id)

--- a/silo/tests/test_customformview.py
+++ b/silo/tests/test_customformview.py
@@ -448,6 +448,7 @@ class CustomFormSaveDataViewTest(TestCase):
             columns='[{"name": "name", "type": "text"},'
                     '{"name": "age", "type": "number"},'
                     '{"name": "city", "type": "text"},'
+                    '{"name": "submitted_by", "type": "text"},'
                     '{"name": "submission_data", "type": "date"},'
                     '{"name": "submission_time", "type": "date"}]',
             reads=[self.read],
@@ -509,6 +510,29 @@ class CustomFormSaveDataViewTest(TestCase):
         self.assertEqual(response.data['detail'], 'It was successfully saved.')
         self.assertEqual(self.silo.data_count, 1)
 
+        request = self.factory.get('/api/silo/{}/data'.format(self.silo.id))
+        request.user = self.tola_user.user
+        view = SiloViewSet.as_view({'get': 'data'})
+        response = view(request, id=self.silo.id)
+        json_content = json.loads(response.content)
+        data = json_content['data'][0]
+
+        self.assertEqual(data['name'], 'John Lennon')
+        self.assertEqual(data['age'], 40)
+        self.assertEqual(data['city'], 'Liverpool')
+
+        # check the submission date
+        submission_date = datetime.now().strftime('%Y-%m-%d')
+        self.assertIn('submission_date', data)
+        self.assertEqual(data['submission_date'], submission_date)
+
+        # the time can be different if the request takes a while
+        self.assertIn('submission_time', data)
+        self.assertTrue(data['submission_time'])
+
+        # it shouldn't have a submitted_by because it wasn't provided
+        self.assertNotIn('submitted_by', data)
+
     def test_save_data_customform_missing_data_superuser(self):
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
@@ -533,13 +557,17 @@ class CustomFormSaveDataViewTest(TestCase):
         self.assertEqual(response.data['detail'], 'Missing data.')
 
     def test_save_data_customform_normaluser(self):
+        user = factories.User(first_name='Homer', last_name='Simpson')
+        sender_tola_user = factories.TolaUser(user=user)
+
         data = {
             'silo_id': self.silo.id,
             'data': {
                 'name': 'John Lennon',
                 'age': 40,
                 'city': 'Liverpool'
-            }
+            },
+            'submitted_by': sender_tola_user.tola_user_uuid.__str__(),
         }
 
         request = self.factory.post('api/customform/save_data',
@@ -572,6 +600,10 @@ class CustomFormSaveDataViewTest(TestCase):
         # the time can be different if the request takes a while
         self.assertIn('submission_time', data)
         self.assertTrue(data['submission_time'])
+
+        # check the name of who sent the data
+        self.assertIn('submitted_by', data)
+        self.assertEqual(data['submitted_by'], sender_tola_user.name)
 
     def test_save_data_customform_no_data_normaluser(self):
         data = {}


### PR DESCRIPTION
## Purpose
When a user creates a form in Activity and publishes it, they would like the table created in Track to have a submission by info for each entry.

## Approach
- I appended the new column to the given ones
- I add the tola user's name when the tola user's uuid is sent to be saved

### Furter Info
Related ticket: #482 
