### PR TITLE
change warning message for making table public

### DIFF
--- a/templates2/display/silo.html
+++ b/templates2/display/silo.html
@@ -637,7 +637,7 @@
                 if (btn_txt == "Make Private") {
                     message = "Do you want to make this table private?";
                 } else {
-                    message = "Public tables can be accessible by everyone. Do you want to continue?";
+                    message = "Public tables can be accessible by everyone, even users who are not in your organizations. Do you want to continue?";
                 }
                 if (window.confirm(message)) {
                     return true;

--- a/templates2/display/silos.html
+++ b/templates2/display/silos.html
@@ -180,7 +180,7 @@
             if (btn_txt == "Public") {
                 message = "Do you want to make this table private?";
             } else {
-                message = "Public tables can be accessible by everyone. Do you want to continue?";
+                message = "Public tables can be accessible by everyone, even users who are not in your organizations. Do you want to continue?";
             }
             if (window.confirm(message)) {
                 return true;


### PR DESCRIPTION
## Purpose
When users want to make table public, They will get warning as 'Public tables can be accessible by everyone, even users who are not in your organizations. Do you want to continue?'

## Approach
Warning message updated.

_Related ticket: #149 
