### PR TITLE
Fix #521 - make merge process based on assigned unique column

### DIFF
--- a/silo/tests/test_siloview.py
+++ b/silo/tests/test_siloview.py
@@ -5,9 +5,11 @@ from rest_framework.test import APIRequestFactory
 
 import factories
 import json
+import random
 from silo.api import SiloViewSet
-from silo.models import LabelValueStore
+from silo.models import LabelValueStore, Silo
 from tola.util import save_data_to_silo
+from silo.views import mergeTwoSilos
 
 
 class SiloListViewTest(TestCase):
@@ -189,3 +191,304 @@ class SiloDataViewTest(TestCase):
             current_rank = int(d['rank'])
             self.assertTrue(last_rank < current_rank)
             last_rank = current_rank
+
+
+class MergeTwoSilosTest(TestCase):
+    def setUp(self):
+        self.mapping_data = """{
+                "0": {
+                    "left_table_cols": ["number"],
+                    "right_table_col": "number",
+                    "merge_type": ""
+                },
+                "left_unmapped_cols": ["first name"],
+                "right_unmapped_cols": ["last name"]
+            }"""
+        self.user = factories.User(username='test_user')
+
+    def tearDown(self):
+        LabelValueStore.objects.delete()
+
+    def _create_silo(self, name, number, value, option):
+        silo = factories.Silo(owner=self.user, name=name, public=True)
+        silo_row = factories.LabelValueStore(silo_id=silo.pk)
+        silo_row['number'] = number
+        if option == 'left':
+            silo_row['first name'] = value
+        elif option == 'right':
+            silo_row['last name'] = value
+        silo_row.save()
+        return silo
+
+    def test_merge_silo(self):
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+        factories.UniqueFields(silo=left_silo, name='number')
+
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+        factories.UniqueFields(silo=right_silo, name='number')
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
+                                 right_silo.pk, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "success",
+                          'message': "Merged data successfully"})
+
+        merged_silo = Silo.objects.get(pk=merged_silo.pk)
+        self.assertEqual(
+            LabelValueStore.objects.filter(silo_id=merged_silo.pk).count(), 1)
+
+        merged_silo_row = LabelValueStore.objects.get(silo_id=merged_silo.pk)
+        self.assertEqual(merged_silo_row['first name'], 'Bob')
+        self.assertEqual(merged_silo_row['last name'], 'Marley')
+
+    def test_merge_silos_without_unique_field_in_left_silo(self):
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+        factories.UniqueFields(silo=right_silo, name='number')
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
+                                 right_silo.pk, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "danger",
+                          'message': "The silo, [%s], must have a unique "
+                                     "column and it should be the same as the "
+                                     "one specified in [%s] silo." %
+                                     (left_silo.name, right_silo.name)})
+
+    def test_merge_silos_without_unique_field_in_right_silo(self):
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+        factories.UniqueFields(silo=left_silo, name='number')
+
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
+                                 right_silo.pk, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "danger",
+                          'message': "The silo, [%s], must have a unique "
+                                     "column and it should be the same as the "
+                                     "one specified in [%s] silo." %
+                                     (right_silo.name, left_silo.name)})
+
+    def test_merge_silos_without_left_silo(self):
+        left_silo_random_id = random.randint(1, 9999)
+
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+        factories.UniqueFields(silo=right_silo, name='number')
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo_random_id,
+                                 right_silo.pk, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "danger",
+                          'message': "Left Silo does not exist: "
+                                     "silo_id=%s" % left_silo_random_id})
+
+    def test_merge_silos_without_right_silo(self):
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+        factories.UniqueFields(silo=left_silo, name='number')
+
+        right_silo_random_id = random.randint(1, 9999)
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
+                                 right_silo_random_id, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "danger",
+                          'message': "Right Silo does not exist: "
+                                     "silo_id=%s" % right_silo_random_id})
+
+    def test_merge_silos_without_merged_silo(self):
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+        factories.UniqueFields(silo=left_silo, name='number')
+
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+        factories.UniqueFields(silo=right_silo, name='number')
+
+        merged_silo_random_id = random.randint(1, 9999)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
+                                 right_silo.pk, merged_silo_random_id)
+
+        self.assertEqual(response,
+                         {'status': "danger",
+                          'message': "Merged Silo does not exist: "
+                                     "silo_id=%s" % merged_silo_random_id})
+
+    def test_merge_silos_with_different_unique_fields(self):
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+        factories.UniqueFields(silo=left_silo, name='first name')
+
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+        factories.UniqueFields(silo=right_silo, name='number')
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
+                                 right_silo.pk, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "danger",
+                          'message': "Both silos (%s, %s) must have the same "
+                                     "column set as unique fields"
+                                     % (left_silo.name, right_silo.name)})
+
+    def test_merge_silos_without_mapped_columns(self):
+        mapping_data = """{
+                        "0": {
+                              "left_table_cols": [],
+                              "right_table_col": "",
+                              "merge_type": ""
+                        },
+                        "left_unmapped_cols": ["first name"],
+                        "right_unmapped_cols": ["last name"]
+                    }"""
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+        factories.UniqueFields(silo=left_silo, name='first name')
+
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+        factories.UniqueFields(silo=right_silo, name='number')
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(mapping_data, left_silo.pk,
+                                 right_silo.pk, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "danger",
+                          'message': "Both silos (%s, %s) must have the same "
+                                     "column set as unique fields"
+                                     % (left_silo.name, right_silo.name)})
+
+    def test_merge_silo_with_specified_merge_type(self):
+        mapping_data = """{
+                        "0": {
+                              "left_table_cols": ["number", "points"],
+                              "right_table_col": "number",
+                              "merge_type": "Avg"
+                        },
+                        "left_unmapped_cols": [],
+                        "right_unmapped_cols": []
+                    }"""
+
+        user = factories.User(username='test_user')
+        left_silo = factories.Silo(owner=user, name='left_silo', public=True)
+        left_silo_r = factories.LabelValueStore(silo_id=left_silo.pk)
+        left_silo_r['number'] = 1
+        left_silo_r['points'] = 5
+        left_silo_r.save()
+        left_silo_r2 = factories.LabelValueStore(silo_id=left_silo.pk)
+        left_silo_r2['number'] = 2
+        left_silo_r2['points'] = 7
+        left_silo_r2.save()
+        factories.UniqueFields(silo=left_silo, name='number')
+
+        right_silo = factories.Silo(owner=user, name='right_silo', public=True)
+        right_silo_r = factories.LabelValueStore(silo_id=right_silo.pk)
+        right_silo_r['number'] = 1
+        right_silo_r.save()
+        right_silo_r2 = factories.LabelValueStore(silo_id=right_silo.pk)
+        right_silo_r2['number'] = 2
+        right_silo_r2.save()
+        factories.UniqueFields(silo=right_silo, name='number')
+
+        merged_silo = factories.Silo(owner=user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(mapping_data, left_silo.pk, right_silo.pk,
+                                 merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "success",
+                          'message': "Merged data successfully"})
+
+        merged_silo = Silo.objects.get(pk=merged_silo.pk)
+        self.assertEqual(
+            LabelValueStore.objects.filter(silo_id=merged_silo.pk).count(), 4)
+
+        merged_silo_rows = LabelValueStore.objects.filter(
+            silo_id=merged_silo.pk)
+        self.assertEqual(merged_silo_rows[0]['number'], 1)
+        self.assertEqual(merged_silo_rows[1]['number'], 2)
+        self.assertEqual(merged_silo_rows[2]['number'], 3.0)
+        self.assertEqual(merged_silo_rows[3]['number'], 4.5)
+
+    def test_merge_silo_with_objectId_unique_field(self):
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+        factories.UniqueFields(silo=left_silo, name='_id')
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+        factories.UniqueFields(silo=right_silo, name='_id')
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
+                                 right_silo.pk, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "success",
+                          'message': "Merged data successfully"})
+
+        merged_silo = Silo.objects.get(pk=merged_silo.pk)
+        self.assertEqual(
+            LabelValueStore.objects.filter(silo_id=merged_silo.pk).count(), 1)
+
+        merged_silo_row = LabelValueStore.objects.get(silo_id=merged_silo.pk)
+        self.assertEqual(merged_silo_row['first name'], 'Bob')
+        self.assertEqual(merged_silo_row['last name'], 'Marley')
+
+    def test_merge_silo_with_datetime_unique_field(self):
+        left_silo = self._create_silo('left_silo', 1, 'Bob', 'left')
+        factories.UniqueFields(silo=left_silo, name='created_date')
+
+        right_silo = self._create_silo('right_silo', 1, 'Marley', 'right')
+        factories.UniqueFields(silo=right_silo, name='created_date')
+
+        merged_silo = factories.Silo(owner=self.user,
+                                     name='merged_silo',
+                                     public=True)
+
+        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
+                                 right_silo.pk, merged_silo.pk)
+
+        self.assertEqual(response,
+                         {'status': "success",
+                          'message': "Merged data successfully"})
+
+        merged_silo = Silo.objects.get(pk=merged_silo.pk)
+        self.assertEqual(
+            LabelValueStore.objects.filter(silo_id=merged_silo.pk).count(), 1)
+
+        merged_silo_row = LabelValueStore.objects.get(silo_id=merged_silo.pk)
+        self.assertEqual(merged_silo_row['first name'], 'Bob')
+        self.assertEqual(merged_silo_row['last name'], 'Marley')

--- a/silo/tests/test_siloview.py
+++ b/silo/tests/test_siloview.py
@@ -9,7 +9,7 @@ import random
 from silo.api import SiloViewSet
 from silo.models import LabelValueStore, Silo
 from tola.util import save_data_to_silo
-from silo.views import mergeTwoSilos
+from silo.views import merge_two_silos
 
 
 class SiloListViewTest(TestCase):
@@ -231,8 +231,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
-                                 right_silo.pk, merged_silo.pk)
+        response = merge_two_silos(self.mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "success",
@@ -256,8 +256,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
-                                 right_silo.pk, merged_silo.pk)
+        response = merge_two_silos(self.mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "danger",
@@ -276,8 +276,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
-                                 right_silo.pk, merged_silo.pk)
+        response = merge_two_silos(self.mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "danger",
@@ -296,8 +296,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo_random_id,
-                                 right_silo.pk, merged_silo.pk)
+        response = merge_two_silos(self.mapping_data, left_silo_random_id,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "danger",
@@ -314,8 +314,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
-                                 right_silo_random_id, merged_silo.pk)
+        response = merge_two_silos(self.mapping_data, left_silo.pk,
+                                   right_silo_random_id, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "danger",
@@ -331,8 +331,8 @@ class MergeTwoSilosTest(TestCase):
 
         merged_silo_random_id = random.randint(1, 9999)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
-                                 right_silo.pk, merged_silo_random_id)
+        response = merge_two_silos(self.mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo_random_id)
 
         self.assertEqual(response,
                          {'status': "danger",
@@ -350,8 +350,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
-                                 right_silo.pk, merged_silo.pk)
+        response = merge_two_silos(self.mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "danger",
@@ -379,8 +379,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(mapping_data, left_silo.pk,
-                                 right_silo.pk, merged_silo.pk)
+        response = merge_two_silos(mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "danger",
@@ -424,8 +424,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(mapping_data, left_silo.pk, right_silo.pk,
-                                 merged_silo.pk)
+        response = merge_two_silos(mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "success",
@@ -452,8 +452,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
-                                 right_silo.pk, merged_silo.pk)
+        response = merge_two_silos(self.mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "success",
@@ -478,8 +478,8 @@ class MergeTwoSilosTest(TestCase):
                                      name='merged_silo',
                                      public=True)
 
-        response = mergeTwoSilos(self.mapping_data, left_silo.pk,
-                                 right_silo.pk, merged_silo.pk)
+        response = merge_two_silos(self.mapping_data, left_silo.pk,
+                                   right_silo.pk, merged_silo.pk)
 
         self.assertEqual(response,
                          {'status': "success",

--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -656,7 +656,7 @@ class DoMergeViewTest(TestCase):
         self.tola_user = factories.TolaUser(organization=self.org)
         self.factory = APIRequestFactory()
 
-    @patch('silo.views.mergeTwoSilos')
+    @patch('silo.views.merge_two_silos')
     @patch('silo.views.MergedSilosFieldMapping')
     def test_merge(self, mock_merged_silos_map, mock_merge_two_silos):
         mock_merge_two_silos.return_value = {
@@ -746,7 +746,7 @@ class DoMergeViewTest(TestCase):
         self.assertIn(left_read, silo.reads.all())
         self.assertIn(right_read, silo.reads.all())
 
-    @patch('silo.views.mergeTwoSilos')
+    @patch('silo.views.merge_two_silos')
     def test_status_danger(self, mock_merge_two_silos):
         mock_merge_two_silos.return_value = {'status': 'danger'}
 
@@ -839,7 +839,7 @@ class DoMergeViewTest(TestCase):
         self.assertEqual(content['message'],
                          'Could not find the right table with id=999')
 
-    @patch('silo.views.mergeTwoSilos')
+    @patch('silo.views.merge_two_silos')
     @patch('silo.views.MergedSilosFieldMapping')
     def test_no_merge_name(self, mock_merged_silos_map, mock_merge_two_silos):
         mock_merge_two_silos.return_value = {

--- a/silo/views.py
+++ b/silo/views.py
@@ -113,7 +113,6 @@ def mergeTwoSilos(mapping_data, lsid, rsid, msid):
 
     l_unmapped_cols = mappings.pop('left_unmapped_cols')
     r_unampped_cols = mappings.pop('right_unmapped_cols')
-
     merged_cols = []
 
     #print("lsid:% rsid:%s msid:%s" % (lsid, rsid, msid))
@@ -146,7 +145,7 @@ def mergeTwoSilos(mapping_data, lsid, rsid, msid):
     try:
         rsilo = Silo.objects.get(pk=rsid)
     except Silo.DoesNotExist as e:
-        msg = "Right Table does not exist: table_id=%s" % rsid
+        msg = "Right Silo does not exist: silo_id=%s" % rsid
         logger.error(msg)
         return {'status': "danger",  'message': msg}
 
@@ -156,7 +155,7 @@ def mergeTwoSilos(mapping_data, lsid, rsid, msid):
         merged_cols.sort()
         addColsToSilo(msilo, merged_cols)
     except Silo.DoesNotExist as e:
-        msg = "Merged Table does not exist: table_id=%s" % msid
+        msg = "Merged Silo does not exist: silo_id=%s" % msid
         logger.error(msg)
         return {'status': "danger",  'message': msg}
 
@@ -164,7 +163,7 @@ def mergeTwoSilos(mapping_data, lsid, rsid, msid):
     r_unique_fields = rsilo.unique_fields.all()
 
     if not r_unique_fields:
-        msg = "The table, [%s], must have a unique column and it should be the same as the one specified in [%s] table." % (rsilo.name, lsilo.name)
+        msg = "The silo, [%s], must have a unique column and it should be the same as the one specified in [%s] silo." % (rsilo.name, lsilo.name)
         logger.error(msg)
         return {'status': "danger",  'message': msg}
 
@@ -195,7 +194,7 @@ def mergeTwoSilos(mapping_data, lsid, rsid, msid):
         filter_criteria = {}
         for uf in r_unique_fields:
             try:
-                filter_criteria.update({str(uf.name): str(merged_row[uf.name])})
+                filter_criteria.update({str(uf.name): merged_row[uf.name]})
             except KeyError as e:
                 # when this excpetion occurs, it means that the col identified
                 # as the unique_col is not present in all rows of the right_table
@@ -211,14 +210,14 @@ def mergeTwoSilos(mapping_data, lsid, rsid, msid):
     # Retrieve the unique_fields set by left table
     l_unique_fields = lsilo.unique_fields.all()
     if not l_unique_fields:
-        msg = "The table, [%s], must have a unique column and it should be the same as the one specified in [%s] table." % (lsilo.name, rsilo.name)
+        msg = "The silo, [%s], must have a unique column and it should be the same as the one specified in [%s] silo." % (lsilo.name, rsilo.name)
         logger.error(msg)
         return {'status': "danger",  'message': msg}
 
     for uf in l_unique_fields:
         # if there are unique fields that are not in the right table then show error
         if not r_unique_fields.filter(name=uf.name).exists():
-            msg = "Both tables (%s, %s) must have the same column set as unique fields" % (lsilo.name, rsilo.name)
+            msg = "Both silos (%s, %s) must have the same column set as unique fields" % (lsilo.name, rsilo.name)
             logger.error(msg)
             return {"status": "danger", "message": msg}
 
@@ -274,7 +273,7 @@ def mergeTwoSilos(mapping_data, lsid, rsid, msid):
         filter_criteria = {}
         for uf in l_unique_fields:
             try:
-                filter_criteria.update({str(uf.name): str(merged_row[uf.name])})
+                filter_criteria.update({str(uf.name): merged_row[uf.name]})
             except KeyError:
                 # when this excpetion occurs, it means that the col identified
                 # as the unique_col is not present in all rows of the left_table


### PR DESCRIPTION
## Purpose
Merge function should merge based on assigned unique column. 

## Approach
Merge function was using string as a keys, this issue prevented update rows on MongoDB and for each row was creating new row at the new merged table..

_Related ticket: #521
