### PR TITLE
Fix #334 - Allow superusers to do anything in the SiloViewSet

### DIFF
--- a/silo/api.py
+++ b/silo/api.py
@@ -21,7 +21,8 @@ from rest_framework import mixins, status
 from .serializers import *
 from .models import (Silo, LabelValueStore, Country, WorkflowLevel1,
                      WorkflowLevel2, TolaUser, Read, ReadType)
-from silo.permissions import *
+from silo.permissions import (IsOwnerOrReadOnly, ReadIsOwnerViewOrWrite,
+                          SiloIsOwnerOrCanRead)
 from tola.util import (getSiloColumnNames, getCompleteSiloColumnNames,
                        save_data_to_silo, JSONEncoder)
 
@@ -316,7 +317,7 @@ class SiloViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_field = 'id'
     # this permission sets seems to break the default permissions set by the restframework
     # permission_classes = (IsOwnerOrReadOnly,)
-    permission_classes = (IsAuthenticated, Silo_IsOwnerOrCanRead,)
+    permission_classes = (IsAuthenticated, SiloIsOwnerOrCanRead)
     filter_fields = ('owner__username','shared__username',
                      'id','tags','public')
     filter_backends = (filters.DjangoFilterBackend,)

--- a/silo/permissions.py
+++ b/silo/permissions.py
@@ -33,6 +33,9 @@ class SiloIsOwnerOrCanRead(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
+        if request.user and request.user.is_superuser:
+            return True
+
         permitted = list()
         is_owner = obj.owner == request.user
         permitted.append(is_owner)

--- a/silo/permissions.py
+++ b/silo/permissions.py
@@ -1,5 +1,6 @@
 from rest_framework import permissions
 
+
 class IsOwnerOrReadOnly(permissions.BasePermission):
     """
     Custom permission to only allow owners of an object to edit it.
@@ -24,7 +25,7 @@ class IsOwnerOrSuperUser(permissions.BasePermission):
         return obj.owner == request.user or request.user.is_superuser
 
 
-class Silo_IsOwnerOrCanRead(permissions.BasePermission):
+class SiloIsOwnerOrCanRead(permissions.BasePermission):
     """
     Custom permission to only allow access to silos if the user
     is the silo owner, if the silo has been shared with the user,
@@ -32,15 +33,15 @@ class Silo_IsOwnerOrCanRead(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
-
-        permitted = [obj.owner == request.user]
+        permitted = list()
+        is_owner = obj.owner == request.user
+        permitted.append(is_owner)
         permitted.append(request.user.is_superuser)
         permitted.append(obj.public)
         permitted.append(request.user.id in obj.shared.values_list('id',
                                                                    flat=True))
-        if hasattr(obj.owner ,'tola_user'):
-            permitted.append(
-                             obj.owner.tola_user.organization ==\
+        if hasattr(obj.owner, 'tola_user'):
+            permitted.append(obj.owner.tola_user.organization ==
                              request.user.tola_user.organization)
 
         return any(permitted)

--- a/silo/tests/test_siloview.py
+++ b/silo/tests/test_siloview.py
@@ -105,7 +105,22 @@ class SiloDataViewTest(TestCase):
             lvs.delete()
         self._import_json(self.silo, self.read)
 
-    def test_data_silo(self):
+    def test_data_silo_superuser(self):
+        another_user = factories.User(first_name='Homer',
+                                      last_name='Simpson', is_superuser=True)
+        factories.TolaUser(user=another_user)
+
+        request = self.factory.get('/api/silo/{}/data'.format(self.silo.id))
+        request.user = another_user
+        view = SiloViewSet.as_view({'get': 'data'})
+        response = view(request, id=self.silo.id)
+
+        self.assertEqual(response.status_code, 200)
+        json_content = json.loads(response.content)
+        self.assertEqual(json_content['recordsTotal'], 20)
+        self.assertEqual(json_content['recordsFiltered'], 20)
+
+    def test_data_silo_owner(self):
         request = self.factory.get('/api/silo/{}/data'.format(self.silo.id))
         request.user = self.tola_user.user
         view = SiloViewSet.as_view({'get': 'data'})


### PR DESCRIPTION
## Purpose
We should allow superusers to do whatever they want with silo's `data`, `get` and `list` endpoint (SiloViewSet) and don't check organization, programs and so on.

### Furter Info
Related ticket: https://github.com/Humanitec/ActivityAPI/issues/334
