### PR TITLE
Fix #503 - add unique id field to google spreadsheets export

### DIFF
--- a/silo/gviews_v4.py
+++ b/silo/gviews_v4.py
@@ -333,7 +333,7 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
         return msgs
 
     try:
-        # if no spreadhsset_id is provided, then create a new spreadsheet
+        # if no spreadsheet_id is provided, then create a new spreadsheet
         if spreadsheet_id is None:
             # create a new google spreadsheet
             body = {"properties":{"title": silo.name}}
@@ -352,7 +352,7 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
                     "msg": msg})
         return msgs
 
-    #get spreadsheet metadata
+    # get spreadsheet metadata
     spreadsheet_name = spreadsheet.get("properties", {}).get("title", "")
     sheet = spreadsheet.get('sheets', '')[0]
     title = sheet.get("properties", {}).get("title", "Sheet1")
@@ -365,7 +365,7 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
                                       user,
                                       silo)
 
-    #get the meta-data from other sheets
+    # get the meta-data from other sheets
     other_title = []
     other_sheet_id = []
     if len(spreadsheet.get('sheets','')) > 0:
@@ -390,12 +390,11 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
             try:
                 if type(row[header]) == list:
                     if header == 'sys__geolocation':
-                        geoString = ",".join(
+                        geo_string = ",".join(
                             [str(h) for h in list(row[header])])
                         values.append({"userEnteredValue":
                                            {"stringValue":
-                                                smart_text(geoString)}})
-
+                                                smart_text(geo_string)}})
                     elif len(row[header]) > 0:
                         try:
                             repeat_data[header].append(row[header])
@@ -409,8 +408,8 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
                                 and header not in other_title:
                             repeat_headers.append(header)
                     else:
-                        values.append({"userEnteredValue": {"stringValue":
-                                                                ""}})
+                        values.append({"userEnteredValue":
+                                           {"stringValue": ""}})
                 else:
                     value = smart_text(row[header])
                     if header == '_id':
@@ -423,7 +422,7 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
                 values.append({"userEnteredValue": {"stringValue": ""}})
         rows.append({"values": values})
 
-    # prepare column names as a header row in spreadsheet
+    # prepare column names as a header row in spreadsheetxw
     values = []
     for header in headers:
         if header == '_id':
@@ -502,7 +501,7 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
     if len(repeat_cells) == 0:
         return msgs
 
-    #use the response to get the sheetid for new sheets added
+    # use the response to get the sheetid for new sheets added
     for reply in response['replies']:
         try:
             other_title.append(reply.get("addSheet").get("properties").get(
@@ -517,16 +516,16 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
         return msgs
 
     requests = []
-    #Add repeats data to the new sheet
-
-    for i in range(0,len(other_title)): # goes through each sheet
+    # Add repeats data to the new sheet
+    # goes through each sheet
+    for i in range(0, len(other_title)):
         rows = [{"values": []}]
         for j, row_set in enumerate(repeat_data.get(other_title[i],[])):
             headers = []
             rows.append({"values":
-                            [{"userEnteredValue": {"stringValue": "From row "
-                                                                "%i" % j},
-                            'userEnteredFormat': {'backgroundColor': {
+                            [{"userEnteredValue":
+                                  {"stringValue": "From row ""%i" % j},
+                              'userEnteredFormat': {'backgroundColor': {
                                 'red':0.75,'green':0.75, 'blue': 0.75}}
                             }]
             })
@@ -546,7 +545,7 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
             values.append({
                           "userEnteredValue": {"stringValue": header},
                           'userEnteredFormat': {'backgroundColor': {
-                              'red':0.5,'green':0.5, 'blue': 0.5}}
+                              'red': 0.5, 'green': 0.5, 'blue': 0.5}}
                           })
 
         # Now update the rows array place holder with real column names
@@ -586,15 +585,15 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
         rows = []
         x_cord = repeat_cells.get(other_title[i],(0,0))[0]
         y_cord = repeat_cells.get(other_title[i],(0,0))[1]
-        for j in range(0,y_cord):
-            rows.append({"values":[
-                        {"userEnteredValue": {
-                        "formulaValue": "=HYPERLINK(\"#gid=%i\","
+        for j in range(0, y_cord):
+            rows.append({"values": [
+                        {"userEnteredValue":
+                             {"formulaValue": "=HYPERLINK(\"#gid=%i\","
                                         "\"See Data\")" % other_sheet_id[i]
                         }}
                 ]})
         # Get hyperlink to actually work
-        if len(rows)>0:
+        if len(rows) > 0:
             requests.append({
                 'updateCells': {
                     'start': {'sheetId': sheet_id, 'rowIndex': 1,

--- a/silo/gviews_v4.py
+++ b/silo/gviews_v4.py
@@ -412,8 +412,13 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
                         values.append({"userEnteredValue": {"stringValue":
                                                                 ""}})
                 else:
+                    value = smart_text(row[header])
+                    if header == '_id':
+                        value = smart_text(row[header]['$oid'])
+
                     values.append({"userEnteredValue": {
-                        "stringValue": smart_text(row[header])}})
+                        "stringValue": value}})
+
             except KeyError:
                 values.append({"userEnteredValue": {"stringValue": ""}})
         rows.append({"values": values})
@@ -421,13 +426,12 @@ def export_to_gsheet_helper(user, spreadsheet_id, silo_id, query, headers):
     # prepare column names as a header row in spreadsheet
     values = []
     for header in headers:
-        values.append({
-                      "userEnteredValue": {"stringValue": header},
-                      'userEnteredFormat':
-                          {'backgroundColor':
-                               {'red':0.5,'green':0.5, 'blue': 0.5}}
-                      })
+        if header == '_id':
+            header = 'id'
 
+        values.append({"userEnteredValue": {"stringValue": header},
+                       'userEnteredFormat': {'backgroundColor':
+                             {'red': 0.5, 'green': 0.5, 'blue': 0.5}}})
     # Now update the rows array place holder with real column names
     rows[0]["values"] = values
 
@@ -623,6 +627,8 @@ def export_to_gsheet(request, id):
 
     cols_to_export = json.loads(request.GET.get('shown_cols', json.dumps(
         getSiloColumnNames(id))))
+
+    cols_to_export.insert(0, '_id')
 
     msgs = export_to_gsheet_helper(request.user, spreadsheet_id, id, query,
                                    cols_to_export)

--- a/silo/tests/test_gviews_v4.py
+++ b/silo/tests/test_gviews_v4.py
@@ -104,6 +104,7 @@ class ExportToGSheetTest(TestCase):
         request = self.factory.get(url, follow=True)
         request.user = self.tola_user.user
         response = gviews_v4.export_to_gsheet(request, self.silo.pk)
+        cols.append('_id')
 
         mock_gsheet_helper.assert_called_once_with(self.tola_user.user,
                                                    spreadsheet_id,
@@ -116,7 +117,7 @@ class ExportToGSheetTest(TestCase):
     def test_export_to_gsheet_no_params(self, mock_gsheet_helper):
         spreadsheet_id = None
         query = {}
-        expected_cols = ['cnt', 'grs', 'tit', 'rank', 'opn', 'yr']
+        expected_cols = ['_id', 'cnt', 'grs', 'tit', 'rank', 'opn', 'yr']
 
         mock_gsheet_helper.return_value = []
 
@@ -182,11 +183,12 @@ class ExportToGSheetTest(TestCase):
     def test_export_to_gsheet_with_cols(self, mock_gsheet_helper):
         spreadsheet_id = None
         query = {}
-        cols = ["yr", "rank", "opn"]
+        cols = ["_id", "yr", "rank", "opn"]
         mock_gsheet_helper.return_value = []
 
         url = reverse('export_new_gsheet', kwargs={'id': self.silo.pk})
-        url = url + '?&query='+str(query)+'&shown_cols=["yr", "rank", "opn"]'
+        url = url + '?&query='+str(query)+'&shown_cols=["yr", ' \
+                                          '"rank", "opn"]'
 
         request = self.factory.get(url, follow=True)
         request.user = self.tola_user.user
@@ -203,7 +205,7 @@ class ExportToGSheetTest(TestCase):
     @patch('silo.gviews_v4.export_to_gsheet_helper')
     def test_export_to_gsheet_with_query(self, mock_gsheet_helper):
         query = {"$or": [{"First_Name": {"$nin": ["1", 1.0, 1]}}]}
-        expected_cols = []
+        expected_cols = ['_id']
         mock_gsheet_helper.return_value = []
 
         url = reverse('export_new_gsheet', kwargs={'id': self.silo.pk})
@@ -226,7 +228,7 @@ class ExportToGSheetTest(TestCase):
     def test_export_to_gsheet_redirect_uri(self, mock_gsheet_helper):
         spreadsheet_id = None
         query = {}
-        expected_cols = ['cnt', 'grs', 'tit', 'rank', 'opn', 'yr']
+        expected_cols = ['_id', 'cnt', 'grs', 'tit', 'rank', 'opn', 'yr']
 
         url = reverse('export_new_gsheet', kwargs={'id': self.silo.pk})
         request = self.factory.get(url, follow=True)


### PR DESCRIPTION
## Purpose
Unique id fields not shown on Google spread sheets export of TolaTables.

## Approach
Unique id field added to export process.

_Related ticket: #503 
