### PR TITLE
make update from google based on unique id

### DIFF
--- a/silo/gviews_v4.py
+++ b/silo/gviews_v4.py
@@ -245,7 +245,10 @@ def import_from_gsheet_helper(user, silo_id, silo_name, spreadsheet_id,
         # build filter_criteria if unique field(s) have been setup for this silo
         for uf in unique_fields:
             try:
-                filter_criteria.update({str(uf.name): str(row[uf.name])})
+                if str(row[uf.name]).isdigit():
+                    filter_criteria.update({str(uf.name): int(row[uf.name])})
+                else:
+                    filter_criteria.update({str(uf.name): str(row[uf.name])})
             except AttributeError as e:
                 logger.warning(e)
         if filter_criteria:


### PR DESCRIPTION
## Purpose
Updating table from google spread sheet isn't working properly. When we set unique id column and try to update table, its generating new rows instead of updating existing rows. 

## Approach
Code issue fixed. Control added to check integer unique fields. 

_Related ticket: #529 
