### PR TITLE
Change warning message when users try to export private silo as JSON

### DIFF
--- a/silo/api.py
+++ b/silo/api.py
@@ -115,25 +115,23 @@ class PublicSiloViewSet(viewsets.ReadOnlyModelViewSet):
         query = request.GET.get('query',"{}")
         filter_fields = json.loads(query)
 
-        shown_cols = set(json.loads(request.GET.get('shown_cols',json.dumps(getSiloColumnNames(id)))))
+        shown_cols = set(
+            json.loads(
+                request.GET.get('shown_cols',
+                                json.dumps(getSiloColumnNames(id)))))
 
-
-        recordsTotal = LabelValueStore.objects(silo_id=id, **filter_fields).count()
-
-
-        #print("offset=%s length=%s" % (offset, length))
-        #page_size = 100
-        #page = int(request.GET.get('page', 1))
-        #offset = (page - 1) * page_size
-        #if page > 0:
-        # workaround until the problem of javascript not increasing the value of length is fixed
-        data = LabelValueStore.objects(silo_id=id, **filter_fields).exclude('create_date', 'edit_date', 'silo_id','read_id')
+        # workaround until the problem of javascript
+        # not increasing the value of length is fixed
+        data = LabelValueStore.objects(
+            silo_id=id,
+            **filter_fields).exclude('create_date', 'edit_date',
+                                     'silo_id', 'read_id')
 
         for col in getCompleteSiloColumnNames(id):
             if col not in shown_cols:
                 data = data.exclude(col)
 
-        sort = str(request.GET.get('sort',''))
+        sort = str(request.GET.get('sort', ''))
         data = data.order_by(sort)
         json_data = json.loads(data.to_json())
         return JsonResponse(json_data, safe=False)

--- a/silo/api.py
+++ b/silo/api.py
@@ -1,12 +1,15 @@
 import json
 import django_filters
 from urlparse import urljoin
+from urllib import urlencode
 from datetime import datetime
 
 from django.http import HttpResponseBadRequest, JsonResponse, HttpResponse
 from django.db.models import Q
 from django.conf import settings
-from django.shortcuts import get_object_or_404
+from django.contrib.auth.models import User
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
 
 from rest_framework import viewsets, filters, permissions
 from rest_framework.decorators import (detail_route, list_route, api_view,
@@ -105,8 +108,10 @@ class PublicSiloViewSet(viewsets.ReadOnlyModelViewSet):
             return HttpResponseBadRequest("The silo_id = %s is invalid" % id)
 
         silo = Silo.objects.get(pk=id)
-        if silo.public == False:
-            return HttpResponse("This table is not public. You must use the private API.")
+        if not silo.public:
+            url = reverse('silos-data', kwargs={'id': silo.pk})
+            return redirect(u'{}?{}'.format(url, request.GET))
+
         query = request.GET.get('query',"{}")
         filter_fields = json.loads(query)
 

--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.test import TestCase, override_settings, Client, RequestFactory
 from django.urls import reverse
-from django.contrib.auth.models import User
 
 from rest_framework.test import APIRequestFactory
-from rest_framework.authtoken.models import Token
 
 from silo.tests import MongoTestCase
 from silo.api import CustomFormViewSet, PublicSiloViewSet
@@ -1912,7 +1910,8 @@ class PublicSiloViewTest(TestCase):
                               organization=self.organizaton,
                               owner=self.tola_user.user)
 
-        request = self.factory.get('/api/public_tables/{}/data'.format(silo.pk))
+        request = self.factory.get(
+            '/api/public_tables/{}/data'.format(silo.pk))
         request.user = self.user
         view = PublicSiloViewSet.as_view({'get': 'data'})
         response = view(request, id=silo.id)

--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from django.test import TestCase, override_settings, Client, RequestFactory
 from django.urls import reverse
+from django.contrib.auth.models import User
 
 from rest_framework.test import APIRequestFactory
+from rest_framework.authtoken.models import Token
 
 from silo.tests import MongoTestCase
-from silo.api import CustomFormViewSet
+from silo.api import CustomFormViewSet, PublicSiloViewSet
 from silo.models import LabelValueStore, Silo, Tag, ReadType
 
 from mock import Mock, patch
@@ -1895,3 +1897,24 @@ class SiloEditViewTest(TestCase):
 
         silo = Silo.objects.get(pk=silo.pk)
         self.assertNotEqual(silo.owner, request_user)
+
+
+class PublicSiloViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.organizaton = factories.Organization()
+        self.user = factories.User(username='Test User')
+        self.tola_user = factories.TolaUser(user=self.user)
+
+    def test_public_silo_view_with_private_silo(self):
+        silo = factories.Silo(name='test',
+                              public=False,
+                              organization=self.organizaton,
+                              owner=self.tola_user.user)
+
+        request = self.factory.get('/api/public_tables/{}/data'.format(silo.pk))
+        request.user = self.user
+        view = PublicSiloViewSet.as_view({'get': 'data'})
+        response = view(request, id=silo.id)
+
+        self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
## Purpose
Currently, when user tries to export private silo as JSON feed, we are warning to redirect them to API. However, we need more clear message with simple instruction.

## Approach
Warning message was changed and user token added to message to inform users about how can they use API. 

_Related ticket: #530
