### PR TITLE
Update link of 500 error page to send email

### DIFF
--- a/templates2/500.html
+++ b/templates2/500.html
@@ -1,3 +1,3 @@
 <h1>Server Error</h1>
 <p>Something went wrong</p>
-<p>Please report this error <a href="http://tola.work" target="_blank">here</a></p>
+<p>Please report this error <a href="mailto:support@toladata.com" target="_blank">here</a></p>


### PR DESCRIPTION
## Purpose
Error message to direct users to support@toladata.com and not to tola.work

### Furter Info
@Menda The template isn't used in any endpoint but they want to update it. :man_shrugging: 
Related ticket: #544 
