### PR TITLE
Hide the Make Private button in the Silo detail page

### DIFF
--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -1150,6 +1150,43 @@ class SiloDetailViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_public_silo_detail_with_owner_user(self):
+        read = factories.Read(read_name="test_data",
+                              owner=self.user)
+        silo = factories.Silo(owner=self.user,
+                              reads=[read],
+                              public=True)
+        url = reverse('silo_detail', args=[silo.pk])
+
+        request = self.factory.get(url)
+        request.user = self.user
+        response = views.silo_detail(request, silo.pk)
+        template_content = response.content
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('<a href="#" id="id_public-{}"'.format(silo.id),
+                      template_content)
+
+    def test_public_silo_detail_with_not_owner_user(self):
+        request_user = factories.User(username='Another User')
+        factories.TolaUser(user=request_user)
+
+        read = factories.Read(read_name="test_data",
+                              owner=self.user)
+        silo = factories.Silo(owner=self.user,
+                              reads=[read],
+                              public=True)
+        url = reverse('silo_detail', args=[silo.pk])
+
+        request = self.factory.get(url)
+        request.user = request_user
+        response = views.silo_detail(request, silo.pk)
+        template_content = response.content
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('<a href="#" id="id_public-{}"'.format(silo.id),
+                         template_content)
+
     def test_silo_detail_share_with_organization(self):
         request_user = factories.User(username='Another User')
         organization = self.tola_user.organization

--- a/templates2/display/silo.html
+++ b/templates2/display/silo.html
@@ -56,7 +56,9 @@
                         </li>
 
                         <li class="list-group-item">
-                            <a href="#" id="id_public-{{silo.pk}}" class="public btn btn-sm {% if silo.public %} btn-warning {% else %} btn-primary {% endif %}" role="button">{% if silo.public %} Make Private {% else %} Make Public {% endif %}</a>
+                            {% if request.user.id == silo.owner.id %}
+                                <a href="#" id="id_public-{{silo.pk}}" class="public btn btn-sm {% if silo.public %} btn-warning {% else %} btn-primary {% endif %}" role="button">{% if silo.public %} Make Private {% else %} Make Public {% endif %}</a>
+                            {% endif %}
                             <a href="/silo_delete/{{ silo.pk }}" class="btn btn-del btn-sm btn-danger" title="Are you sure you want to delete this table? All of the data stored in this table will also be deleted."><span class="glyphicon glyphicon-trash" title="Delete"></span> Delete Table</a>
                             <a href="/edit_column_order/{{silo.pk}}" class="btn btn-primary">Edit Column Order</a>
                             <a href="/edit_filter/{{ silo.pk }}/" class="btn btn-primary"> Filter Data</a>


### PR DESCRIPTION
## Purpose
Hide the Make Private button of public silos (`/silo_details/`) for not owners.

### Furter Info
Related ticket: #545 
