### PR TITLE
fill uid field of UserSocialAuth model

### DIFF
--- a/silo/tests/test_views.py
+++ b/silo/tests/test_views.py
@@ -1050,6 +1050,37 @@ class OneDriveReadTest(TestCase):
 
         self.assertIn('Invalid Form', messages)
 
+    def test_new_read_post_creates_uuid(self):
+        """
+        POST for onedrive should create uuid for UserSocialAuth, otherwise
+        unique_together will not be unique.
+        """
+        read_type = ReadType.objects.get(read_type="OneDrive")
+
+        params = {
+            'owner': self.tola_user.user.pk,
+            'type': read_type.pk,
+            'read_name': 'TEST READ ONEDRIVE',
+            'description': 'TEST DESCRIPTION for test read source',
+            'onedrive_file': 'TEST10000100',
+            'onedrive_access_token': 'TEST_DUMMY_TOKEN',
+            'create_date': '2018-01-26 12:33:00',
+        }
+        request = self.factory.post(self.new_read_url, data=params)
+        request.user = self.tola_user.user
+
+        response = views.showRead(request, 0)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/import_onedrive/1/')
+
+        # check for social auth updated
+
+        social_auth = UserSocialAuth.objects.get(user=self.tola_user.user,
+                                                 provider='microsoft-graph')
+
+        self.assertNotEqual(social_auth.uid, '')
+
 
 class SiloDetailViewTest(TestCase):
     def setUp(self):

--- a/silo/views.py
+++ b/silo/views.py
@@ -9,6 +9,7 @@ import json
 from collections import OrderedDict
 from requests.auth import HTTPDigestAuth
 import tempfile
+import uuid
 
 from pymongo import MongoClient
 
@@ -792,6 +793,7 @@ def showRead(request, id):
                 social_auth, created = UserSocialAuth.objects.get_or_create(
                         provider='microsoft-graph', user=request.user)
                 social_auth.extra_data = extra_data
+                social_auth.uid = str(uuid.uuid4())
                 social_auth.save()
 
                 return HttpResponseRedirect("/import_onedrive/" + str(


### PR DESCRIPTION
## Purpose
After one user succesfully import data from onedrive, other users can not import data because User_social_auth table (which store tokens for onedrive access) has uid as a unique field and that is empty. Therefore, new users always get key conflict error. We need to fill that uid field with unique values.

## Approach
UID field filled with generated UUID before it saved. So, each row will have its own unique value as a uid.

_Related ticket: #547 
