### PR TITLE
Run loadinitialdata on production without errors

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,3 +26,4 @@ fabric==1.14.0
 celery==4.1.1
 django-celery-results==1.0.1
 redis==2.10.5
+factory_boy==2.9.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,4 @@
 -r base.txt
 
 django-debug-toolbar==1.8
-factory_boy==2.9.2
 mock==2.0.0


### PR DESCRIPTION
We run load initial data on production but it have some errors with
dependencies on factory_boy,  so move factory_boy to base requirements.

